### PR TITLE
Fix typos in changelog, fix Makefile release process

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,13 +10,13 @@ Changelog
 0.0.17
 ~~~~~~
 
--  Fix Typose in README
+-  Fix typos in README
 -  Add notes on Dead Letter Queues to README
 
 0.0.16
 ~~~~~~
 
--  Switch README to ReStructed Text (.rst) format so it renders on PyPI
+-  Switch README to reStructuredText (.rst) format so it renders on PyPI
 
 0.0.15
 ~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ publish: clean tag
 
 tag:
 	@if [ $$(git rev-list $$(git describe --abbrev=0 --tags)..HEAD --count) -gt 0 ]; then \
-		if [ $$(git log  -n 1 --oneline $$(git describe --abbrev=0 --tags)..HEAD CHANGELOG.md | wc -l) -gt 0 ]; then \
+		if [ $$(git log  -n 1 --oneline $$(git describe --abbrev=0 --tags)..HEAD CHANGELOG.rst | wc -l) -gt 0 ]; then \
 			git tag $$(python setup.py --version) && git push --tags || echo 'Version already released, update your version!'; \
 		else \
 			echo "CHANGELOG not updated since last release!"; \


### PR DESCRIPTION
Missed a reference to CHANGELOG.md in e4869377a139b90b4dd4b4b962914c5a1046dc28.