### PR TITLE
Allow overwriting the `delay_seconds` attibute at call time

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -1,4 +1,4 @@
-coverage==3.6
+coverage==4.4.1
 mock==1.0.1
 moto==0.4.3
 nose==1.3.0

--- a/pyqs/decorator.py
+++ b/pyqs/decorator.py
@@ -32,6 +32,11 @@ def task_delayer(func_to_delay, queue_name, delay_seconds=None, override=False):
     def wrapper(*args, **kwargs):
         queue = get_or_create_queue(queue_name)
 
+        _delay_seconds = delay_seconds
+        if '_delay_seconds' in kwargs:
+            _delay_seconds = kwargs['_delay_seconds']
+            del kwargs['_delay_seconds']
+
         logger.info("Delaying task %s: %s, %s", function_path, args, kwargs)
         message_dict = {
             'task': function_path,
@@ -41,7 +46,7 @@ def task_delayer(func_to_delay, queue_name, delay_seconds=None, override=False):
 
         message = Message()
         message.set_body(json.dumps(message_dict))
-        queue.write(message, delay_seconds)
+        queue.write(message, _delay_seconds)
 
     return wrapper
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -52,9 +52,8 @@ def test_specified_queue():
 @mock_sqs()
 def test_message_delay():
     """
-    Test delaying task to specific queue
+    Test delaying task with delay_seconds
     """
-
     conn = boto.connect_sqs()
 
     delayed_task.delay()
@@ -65,6 +64,40 @@ def test_message_delay():
     queue = all_queues[0]
     queue.name.should.equal("delayed")
     queue.count().should.equal(0)
+
+
+@mock_sqs()
+def test_message_add_delay():
+    """
+    Test configuring the delay time of a task
+    """
+    conn = boto.connect_sqs()
+
+    send_email.delay("email subject", _delay_seconds=5)
+
+    all_queues = conn.get_all_queues()
+    len(all_queues).should.equal(1)
+
+    queue = all_queues[0]
+    queue.name.should.equal("email")
+    queue.count().should.equal(0)
+
+
+@mock_sqs()
+def test_message_no_delay():
+    """
+    Test removing the delay time of a task
+    """
+    conn = boto.connect_sqs()
+
+    delayed_task.delay(_delay_seconds=0)
+
+    all_queues = conn.get_all_queues()
+    len(all_queues).should.equal(1)
+
+    queue = all_queues[0]
+    queue.name.should.equal("delayed")
+    queue.count().should.equal(1)
 
 
 @mock_sqs()


### PR DESCRIPTION
This makes it easier to call a task immediately, and let that task call itself after a certain delay in case it's waiting for something to happen.

The way to do this before would be to have two different tasks which have the same functionality but with the `delay_seconds` attribute being the only difference.

It can also be used to clear any `delay_seconds` properties on other tasks by setting it to either `0` or `None`.