### PR TITLE
Upgrade to boto3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ script:
 
 after_success:
   - coveralls
+
+env:
+  - AWS_REGION=eu-west-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ after_success:
 
 env:
   - AWS_REGION=eu-west-1
+  - AWS_DEFAULT_REGION=eu-west-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ after_success:
   - coveralls
 
 env:
-  - AWS_REGION=eu-west-1
   - AWS_DEFAULT_REGION=eu-west-1

--- a/development.txt
+++ b/development.txt
@@ -1,6 +1,6 @@
 coverage==4.4.1
 mock==1.0.1
-moto==0.4.3
+moto==1.1.25
 nose==1.3.0
 pre-commit==0.7.6
 sure==1.2.2

--- a/pyqs/decorator.py
+++ b/pyqs/decorator.py
@@ -8,9 +8,10 @@ from .utils import function_to_import_path
 
 logger = logging.getLogger("pyqs")
 
+
 def get_or_create_queue(queue_name):
     sqs = boto3.resource('sqs')
-    print queue_name
+
     try:
         queue = sqs.get_queue_by_name(QueueName=queue_name)
     except ClientError as e:
@@ -28,7 +29,7 @@ def task_delayer(func_to_delay, queue_name, delay_seconds=None, override=False):
         # If no queue specified, use the function_path for the queue, be sure
         # to replace the dots with underscores, as dots are not accepted as
         # queue names :(
-        queue_name = function_path.replace('.','-')
+        queue_name = function_path.replace('.', '-')
 
     def wrapper(*args, **kwargs):
         queue = get_or_create_queue(queue_name)

--- a/pyqs/decorator.py
+++ b/pyqs/decorator.py
@@ -11,11 +11,13 @@ logger = logging.getLogger("pyqs")
 
 def get_or_create_queue(queue_name):
     sqs = boto3.resource('sqs')
-
     try:
         queue = sqs.get_queue_by_name(QueueName=queue_name)
     except ClientError as e:
         if 'QueueDoesNotExist' == e.__class__.__name__:
+            queue = sqs.create_queue(QueueName=queue_name)
+        elif 'ClientError' == e.__class__.__name__:
+            # moto client :(
             queue = sqs.create_queue(QueueName=queue_name)
         else:
             raise(e)

--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -46,33 +46,6 @@ Run PyQS workers for the given queues
     )
 
     parser.add_argument(
-        "--access-key-id",
-        dest="access_key_id",
-        type=str,
-        default=None,
-        help='AWS_ACCESS_KEY_ID used by Boto',
-        action="store",
-    )
-
-    parser.add_argument(
-        "--secret-access-key",
-        dest="secret_access_key",
-        type=str,
-        default=None,
-        help='AWS_SECRET_ACCESS_KEY used by Boto',
-        action="store",
-    )
-
-    parser.add_argument(
-        "--region",
-        dest="region",
-        type=str,
-        default="us-east-1",
-        help='AWS Region to connect to SQS',
-        action="store",
-    )
-
-    parser.add_argument(
         "--interval",
         dest="interval",
         type=float,
@@ -105,18 +78,15 @@ Run PyQS workers for the given queues
         queue_prefixes=args.queues,
         concurrency=args.concurrency,
         logging_level=args.logging_level,
-        region=args.region,
-        access_key_id=args.access_key_id,
-        secret_access_key=args.secret_access_key,
         interval=args.interval,
         batchsize=args.batchsize,
         prefetch_multiplier=args.prefetch_multiplier
     )
 
 
-def _main(queue_prefixes, concurrency=5, logging_level="WARN", region='us-east-1', access_key_id=None, secret_access_key=None, interval=1, batchsize=10, prefetch_multiplier=2):
+def _main(queue_prefixes, concurrency=5, logging_level="WARN", interval=1, batchsize=10, prefetch_multiplier=2):
     logging.basicConfig(format="[%(levelname)s]: %(message)s", level=getattr(logging, logging_level))
     logger.info("Starting PyQS version {}".format(__version__))
-    manager = ManagerWorker(queue_prefixes, concurrency, interval, batchsize, prefetch_multiplier=prefetch_multiplier, region=region, access_key_id=access_key_id, secret_access_key=secret_access_key)
+    manager = ManagerWorker(queue_prefixes, concurrency, interval, batchsize, prefetch_multiplier=prefetch_multiplier)
     manager.start()
     manager.sleep()

--- a/pyqs/utils.py
+++ b/pyqs/utils.py
@@ -4,7 +4,7 @@ import pickle
 
 
 def decode_message(message):
-    message_body = message.get_body()
+    message_body = message.body
     json_body = json.loads(message_body)
     if 'task' in message_body:
         return json_body

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -168,7 +168,6 @@ class ProcessWorker(BaseWorker):
         else:
             end_time = time.clock()
 
-            # self.conn.get_status('DeleteMessage', params, queue_id)
             boto3.resource('sqs').Message(queue_url, receipt_handle).delete()
             logger.info(
                 "Processed task {} in {:.4f} seconds with args: {} and kwargs: {}".format(

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -16,24 +16,13 @@ try:
 except ImportError:
     from Queue import Empty, Full
 
-import boto
+import boto3
 
 from pyqs.utils import decode_message
 
 MESSAGE_DOWNLOAD_BATCH_SIZE = 10
 LONG_POLLING_INTERVAL = 20
 logger = logging.getLogger("pyqs")
-
-
-def get_conn(region=None, access_key_id=None, secret_access_key=None):
-    return boto.connect_sqs(aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key, region=_get_region(region))
-
-
-def _get_region(region_name):
-    if region_name is not None:
-        for region in boto.sqs.regions():
-            if region.name == region_name:
-                return region
 
 
 class BaseWorker(Process):
@@ -57,7 +46,7 @@ class ReadWorker(BaseWorker):
     def __init__(self, sqs_queue, internal_queue, batchsize, *args, **kwargs):
         super(ReadWorker, self).__init__(*args, **kwargs)
         self.sqs_queue = sqs_queue
-        self.visibility_timeout = self.sqs_queue.get_timeout()
+        self.visibility_timeout = float(self.sqs_queue.attributes['VisibilityTimeout'])
         self.internal_queue = internal_queue
         self.batchsize = batchsize
 
@@ -65,17 +54,18 @@ class ReadWorker(BaseWorker):
         # Set the child process to not receive any keyboard interrupts
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-        logger.info("Running ReadWorker: {}, pid: {}".format(self.sqs_queue.name, os.getpid()))
+        logger.info("Running ReadWorker: {}, pid: {}".format(self.sqs_queue.url, os.getpid()))
         while not self.should_exit.is_set() and self.parent_is_alive():
             self.read_message()
         self.internal_queue.close()
         self.internal_queue.cancel_join_thread()
 
     def read_message(self):
-        messages = self.sqs_queue.get_messages(self.batchsize, wait_time_seconds=LONG_POLLING_INTERVAL)
-        logger.info("Successfully got {} messages from SQS queue {}".format(len(messages), self.sqs_queue.name))  # noqa
+        messages = self.sqs_queue.receive_messages(MaxNumberOfMessages=self.batchsize, WaitTimeSeconds=LONG_POLLING_INTERVAL)
+        logger.info("Successfully got {} messages from SQS queue {}".format(len(messages), self.sqs_queue.url))  # noqa
         start = time.time()
         for message in messages:
+            logger.debug("Message loop")
             end = time.time()
             if int(end - start) >= self.visibility_timeout:
                 # Don't add any more messages since they have re-appeared in the sqs queue
@@ -87,8 +77,9 @@ class ReadWorker(BaseWorker):
             message_body = decode_message(message)
             try:
                 packed_message = {
-                    "queue": self.sqs_queue.id,
-                    "message": message,
+                    "queue_url": self.sqs_queue.url,
+                    "message": message_body,
+                    "receipt_handle": message.receipt_handle,
                     "start_time": start,
                     "timeout": self.visibility_timeout,
                 }
@@ -98,17 +89,14 @@ class ReadWorker(BaseWorker):
                 logger.warning(msg)
                 continue
             else:
-                logger.debug("Message successfully added to internal queue from SQS queue {} with body: {}".format(self.sqs_queue.name, message_body))  # noqa
+                logger.debug("Message successfully added to internal queue from SQS queue {} with body: {}".format(self.sqs_queue.url, message_body))  # noqa
 
 
 class ProcessWorker(BaseWorker):
 
-    def __init__(self, internal_queue, interval, connection_args=None, *args, **kwargs):
+    def __init__(self, internal_queue, interval, *args, **kwargs):
         super(ProcessWorker, self).__init__(*args, **kwargs)
-        if connection_args is None:
-            self.conn = get_conn()
-        else:
-            self.conn = get_conn(**connection_args)
+        self.conn = boto3.client('sqs')
         self.internal_queue = internal_queue
         self.interval = interval
         self._messages_to_process_before_shutdown = 100
@@ -136,11 +124,11 @@ class ProcessWorker(BaseWorker):
         except Empty:
             # Return False if we did not attempt to process any messages
             return False
-        message = packed_message['message']
-        queue_id = packed_message['queue']
+        message_body = packed_message['message']
+        queue_url = packed_message['queue_url']
         fetch_time = packed_message['start_time']
         timeout = packed_message['timeout']
-        message_body = decode_message(message)
+        receipt_handle = packed_message['receipt_handle']
         full_task_path = message_body['task']
         args = message_body['args']
         kwargs = message_body['kwargs']
@@ -179,8 +167,9 @@ class ProcessWorker(BaseWorker):
             return True
         else:
             end_time = time.clock()
-            params = {'ReceiptHandle': message.receipt_handle}
-            self.conn.get_status('DeleteMessage', params, queue_id)
+
+            # self.conn.get_status('DeleteMessage', params, queue_id)
+            boto3.resource('sqs').Message(queue_url, receipt_handle).delete()
             logger.info(
                 "Processed task {} in {:.4f} seconds with args: {} and kwargs: {}".format(
                     full_task_path,
@@ -194,12 +183,7 @@ class ProcessWorker(BaseWorker):
 
 class ManagerWorker(object):
 
-    def __init__(self, queue_prefixes, worker_concurrency, interval, batchsize, prefetch_multiplier=2, region='us-east-1', access_key_id=None, secret_access_key=None):
-        self.connection_args = {
-            "region": region,
-            "access_key_id": access_key_id,
-            "secret_access_key": secret_access_key,
-        }
+    def __init__(self, queue_prefixes, worker_concurrency, interval, batchsize, prefetch_multiplier=2):
         self.batchsize = batchsize
         if batchsize > MESSAGE_DOWNLOAD_BATCH_SIZE:
             self.batchsize = MESSAGE_DOWNLOAD_BATCH_SIZE
@@ -227,7 +211,7 @@ class ManagerWorker(object):
 
     def _initialize_worker_children(self, number):
         for index in range(number):
-            self.worker_children.append(ProcessWorker(self.internal_queue, self.interval, connection_args=self.connection_args))
+            self.worker_children.append(ProcessWorker(self.internal_queue, self.interval))
 
     def load_queue_prefixes(self, queue_prefixes):
         self.queue_prefixes = queue_prefixes
@@ -237,14 +221,19 @@ class ManagerWorker(object):
             logger.info("[Queue]\t{}".format(queue_prefix))
 
     def get_queues_from_queue_prefixes(self, queue_prefixes):
-        all_queues = get_conn(**self.connection_args).get_all_queues()
+        queue_urls = boto3.client('sqs').list_queues()['QueueUrls']
+
+        logger.debug("Queue_urls: %s", queue_urls)
+
         matching_queues = []
         for prefix in queue_prefixes:
-            matching_queues.extend([
-                queue for queue in all_queues if
-                fnmatch.fnmatch(queue.name, prefix)
-            ])
-        logger.info("Found matching SQS Queues: {}".format([q.name for q in matching_queues]))
+            # replace dots with underscores, so we match the queue creation
+            prefix = prefix.replace('.', '_')
+            for queue_url in queue_urls:
+                if fnmatch.fnmatch(queue_url.split('/')[-1], prefix):
+                    matching_queues.append(boto3.resource('sqs').Queue(queue_url))
+
+        logger.info("Found matching SQS Queues: {}".format([q.url for q in matching_queues]))
         return matching_queues
 
     def setup_internal_queue(self, worker_concurrency):
@@ -314,6 +303,6 @@ class ManagerWorker(object):
             if not worker.is_alive():
                 logger.info("Worker Process {} is no longer responding, spawning a new worker.".format(worker.pid))
                 self.worker_children.pop(index)
-                worker = ProcessWorker(self.internal_queue, self.interval, connection_args=self.connection_args)
+                worker = ProcessWorker(self.internal_queue, self.interval)
                 worker.start()
                 self.worker_children.append(worker)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         ],
     },
     install_requires=[
-        'boto>=2.32.1'
+        'boto3>=1.4.4'
     ],
     packages=[n for n in find_packages() if not n.startswith('tests')],
     include_package_data=True,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,6 @@
 import json
 
-import boto
+import boto3
 from moto import mock_sqs
 
 from .tasks import index_incrementer, send_email, delayed_task, custom_path_task
@@ -11,19 +11,19 @@ def test_basic_delay():
     """
     Test delaying task to default queue
     """
-    conn = boto.connect_sqs()
-    conn.create_queue("tests.tasks.index_incrementer")
+    client = boto3.client('sqs')
+    client.create_queue(QueueName="tests-tasks-index_incrementer")
 
     index_incrementer.delay("foobar", **{'extra': 'more'})
 
-    all_queues = conn.get_all_queues()
+    all_queues = boto3.client('sqs').list_queues()['QueueUrls']
     len(all_queues).should.equal(1)
 
-    queue = all_queues[0]
-    queue.name.should.equal("tests.tasks.index_incrementer")
-    queue.count().should.equal(1)
+    queue = boto3.resource('sqs').Queue(all_queues[0])
+    queue.url.should.contain("tests-tasks-index_incrementer")
+    int(queue.attributes['ApproximateNumberOfMessages']).should.equal(1)
 
-    message = queue.get_messages()[0].get_body()
+    message = queue.receive_messages()[0].body
     message_dict = json.loads(message)
     message_dict.should.equal({
         'task': 'tests.tasks.index_incrementer',
@@ -37,16 +37,15 @@ def test_specified_queue():
     """
     Test delaying task to specific queue
     """
-    conn = boto.connect_sqs()
-
     send_email.delay("email subject")
 
-    all_queues = conn.get_all_queues()
+    all_queues = boto3.client('sqs').list_queues()['QueueUrls']
     len(all_queues).should.equal(1)
 
-    queue = all_queues[0]
-    queue.name.should.equal("email")
-    queue.count().should.equal(1)
+    queue = boto3.resource('sqs').Queue(all_queues[0])
+    queue.url.should.contain("email")
+
+    int(queue.attributes['ApproximateNumberOfMessages']).should.equal(1)
 
 
 @mock_sqs()
@@ -54,16 +53,15 @@ def test_message_delay():
     """
     Test delaying task with delay_seconds
     """
-    conn = boto.connect_sqs()
-
     delayed_task.delay()
 
-    all_queues = conn.get_all_queues()
+    all_queues = boto3.client('sqs').list_queues()['QueueUrls']
     len(all_queues).should.equal(1)
 
-    queue = all_queues[0]
-    queue.name.should.equal("delayed")
-    queue.count().should.equal(0)
+    queue = boto3.resource('sqs').Queue(all_queues[0])
+    queue.url.should.contain("delayed")
+
+    int(queue.attributes['ApproximateNumberOfMessages']).should.equal(0)
 
 
 @mock_sqs()
@@ -71,16 +69,15 @@ def test_message_add_delay():
     """
     Test configuring the delay time of a task
     """
-    conn = boto.connect_sqs()
-
     send_email.delay("email subject", _delay_seconds=5)
 
-    all_queues = conn.get_all_queues()
+    all_queues = boto3.client('sqs').list_queues()['QueueUrls']
     len(all_queues).should.equal(1)
 
-    queue = all_queues[0]
-    queue.name.should.equal("email")
-    queue.count().should.equal(0)
+    queue = boto3.resource('sqs').Queue(all_queues[0])
+    queue.url.should.contain("email")
+
+    int(queue.attributes['ApproximateNumberOfMessages']).should.equal(0)
 
 
 @mock_sqs()
@@ -88,16 +85,14 @@ def test_message_no_delay():
     """
     Test removing the delay time of a task
     """
-    conn = boto.connect_sqs()
-
     delayed_task.delay(_delay_seconds=0)
 
-    all_queues = conn.get_all_queues()
+    all_queues = boto3.client('sqs').list_queues()['QueueUrls']
     len(all_queues).should.equal(1)
 
-    queue = all_queues[0]
-    queue.name.should.equal("delayed")
-    queue.count().should.equal(1)
+    queue = boto3.resource('sqs').Queue(all_queues[0])
+    queue.url.should.contain("delayed")
+    int(queue.attributes['ApproximateNumberOfMessages']).should.equal(1)
 
 
 @mock_sqs()
@@ -105,16 +100,14 @@ def test_custom_function_path():
     """
     Test delaying task with custom function path
     """
-    conn = boto.connect_sqs()
-
     custom_path_task.delay()
 
-    all_queues = conn.get_all_queues()
-    queue = all_queues[0]
-    queue.name.should.equal("foobar")
-    queue.count().should.equal(1)
+    all_queues = boto3.client('sqs').list_queues()['QueueUrls']
+    queue = boto3.resource('sqs').Queue(all_queues[0])
+    queue.url.should.contain("foobar")
+    int(queue.attributes['ApproximateNumberOfMessages']).should.equal(1)
 
-    message = queue.get_messages()[0].get_body()
+    message = queue.receive_messages()[0].body
     message_dict = json.loads(message)
     message_dict.should.equal({
         'task': 'custom_function.path',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,3 +52,8 @@ class ThreadWithReturnValue3(Thread):
     def join(self):
         Thread.join(self)
         return self._return
+
+
+class Struct:
+    def __init__(self, foo):
+        self.__dict__ = foo


### PR DESCRIPTION
Hi!

It took some effort, but I upgraded the whole package to use boto3 instead of the (old) boto package. Also, it now is compatible with the (new?) sqs queue naming scheme.

The new naming scheme doesn't allow for dots (only alphanumeric, slashes and underscores). I also rewrote all of the tests, and they all pass, there is one test which doesn't work, but I think that's a problem with my local setup, not so much with the test.

I saw there was an (old) boto3 branch, which wasn't finished, I hope this helps.

I also removed the connection details (iam credentials + region), not sure if we want this, but boto3 will catch the credentials from several sources (eg: environment variables, boto3 config file, aws credentials file, instance profile), so I think it's overkill to keep it, but would be more than happy to put them back.