### PR TITLE
Don't log message retrieve success when there are 0 messages

### DIFF
--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -77,7 +77,10 @@ class ReadWorker(BaseWorker):
             MaxNumberOfMessages=self.batchsize,
             WaitTimeSeconds=LONG_POLLING_INTERVAL,
         ).get('Messages', [])
-        logger.info("Successfully got {} messages from SQS queue {}".format(len(messages), self.queue_url))  # noqa
+
+        if len(messages) > 0:
+            logger.info("Successfully got {} messages from SQS queue {}".format(len(messages), self.queue_url))  # noqa
+
         start = time.time()
         for message in messages:
             end = time.time()

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -78,8 +78,7 @@ class ReadWorker(BaseWorker):
             WaitTimeSeconds=LONG_POLLING_INTERVAL,
         ).get('Messages', [])
 
-        if len(messages) > 0:
-            logger.info("Successfully got {} messages from SQS queue {}".format(len(messages), self.queue_url))  # noqa
+        logger.debug("Successfully got {} messages from SQS queue {}".format(len(messages), self.queue_url))  # noqa
 
         start = time.time()
         for message in messages:


### PR DESCRIPTION
Hi,

First of all, thanks for the work put into pyqs! So far it seems to be a nice and simple queue processor (coming from celery...).

This is a PR to not log the 'Successfully got messages' statement if there are 0 messages. If this is unwise/unwanted, maybe we can change the loglevel to debug (`logger.debug`) instead? Let me know what you think. Thank you 