### PR TITLE
Add current directory to PYTHONPATH

### DIFF
--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -3,6 +3,8 @@
 from __future__ import unicode_literals
 
 import logging
+import os
+import sys
 from argparse import ArgumentParser
 
 from .worker import ManagerWorker
@@ -114,9 +116,16 @@ Run PyQS workers for the given queues
     )
 
 
+def _add_cwd_to_path():
+    cwd = os.getcwd()
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
+
 def _main(queue_prefixes, concurrency=5, logging_level="WARN", region='us-east-1', access_key_id=None, secret_access_key=None, interval=1, batchsize=10, prefetch_multiplier=2):
     logging.basicConfig(format="[%(levelname)s]: %(message)s", level=getattr(logging, logging_level))
     logger.info("Starting PyQS version {}".format(__version__))
+    _add_cwd_to_path()
     manager = ManagerWorker(queue_prefixes, concurrency, interval, batchsize, prefetch_multiplier=prefetch_multiplier, region=region, access_key_id=access_key_id, secret_access_key=secret_access_key)
     manager.start()
     manager.sleep()


### PR DESCRIPTION
Add current directory to PYTHONPATH, so importlib works with things like virtualenv, conda, etc.

Currently the PYTHONPATH for these isolated Python environments only contains path under the folders that are generated by these environments and global python library paths when launch as a script.

For example, a typical folder setup of virtualenv is like this:

```
project/my_lib/
project/my_lib/__init__.py
project/my_lib/some_module.py
project/venv/**
```

If I simplify start PyQS from the project folder, and launch a task from another process by

```
from my_lib.some_module import some_task
some_task.delay()
```

It will fail with

```
ImportError: No module named my_lib
```

Because the current directory is not in PYTHONPATH. 

This patch fixes this problem.