### PR TITLE
Fix indentation error in main.py

### DIFF
--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -128,7 +128,7 @@ def _add_cwd_to_path():
         sys.path.insert(0, cwd)
 
 
-        def _main(queue_prefixes, concurrency=5, logging_level="WARN",
+def _main(queue_prefixes, concurrency=5, logging_level="WARN",
           region='us-east-1', access_key_id=None, secret_access_key=None,
           interval=1, batchsize=10, prefetch_multiplier=2):
     logging.basicConfig(


### PR DESCRIPTION
Indentation of `main.py` in master branch is broken. This results in IndentationError when `pyqs` command is executed. This PR fixes the problem.

Before:

```
(venv) $ pyqs
Traceback (most recent call last):
  File "/private/tmp/test_pyqs/venv/bin/pyqs", line 11, in <module>
    load_entry_point('pyqs==0.1.1', 'console_scripts', 'pyqs')()
  File "/private/tmp/test_pyqs/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/private/tmp/test_pyqs/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/private/tmp/test_pyqs/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/private/tmp/test_pyqs/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/private/tmp/test_pyqs/venv/lib/python3.7/site-packages/pyqs/main.py", line 134
    logging.basicConfig(
    ^
IndentationError: expected an indented block
```

After:

```
(venv) $ pyqs
usage: pyqs [-h] [-c CONCURRENCY] [--loglevel LOGGING_LEVEL]
            [--access-key-id ACCESS_KEY_ID]
            [--secret-access-key SECRET_ACCESS_KEY] [--region REGION]
            [--interval INTERVAL] [--batchsize BATCHSIZE]
            [--prefetch-multiplier PREFETCH_MULTIPLIER]
            QUEUE_NAME [QUEUE_NAME ...]
pyqs: error: the following arguments are required: QUEUE_NAME
```