### PR TITLE
Honor AWS region configured by .aws/config or env var

### DIFF
--- a/pyqs/decorator.py
+++ b/pyqs/decorator.py
@@ -4,16 +4,13 @@ import logging
 import boto3
 from botocore.exceptions import ClientError
 
-from .utils import function_to_import_path
+from .utils import get_aws_region_name, function_to_import_path
 
 logger = logging.getLogger("pyqs")
 
 
 def get_or_create_queue(queue_name):
-    region_name = boto3.session.Session().region_name
-    if not region_name:
-        region_name = 'us-east-1'
-
+    region_name = get_aws_region_name()
     sqs = boto3.resource('sqs', region_name=region_name)
     try:
         return sqs.get_queue_by_name(QueueName=queue_name)

--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -72,7 +72,7 @@ Run PyQS workers for the given queues
         "--region",
         dest="region",
         type=str,
-        default="us-east-1",
+        default=None,
         help='AWS Region to connect to SQS',
         action="store",
     )
@@ -129,7 +129,7 @@ def _add_cwd_to_path():
 
 
 def _main(queue_prefixes, concurrency=5, logging_level="WARN",
-          region='us-east-1', access_key_id=None, secret_access_key=None,
+          region=None, access_key_id=None, secret_access_key=None,
           interval=1, batchsize=10, prefetch_multiplier=2):
     logging.basicConfig(
         format="[%(levelname)s]: %(message)s",

--- a/pyqs/utils.py
+++ b/pyqs/utils.py
@@ -2,6 +2,8 @@ import base64
 import json
 import pickle
 
+import boto3
+
 
 def decode_message(message):
     message_body = message['Body']
@@ -26,3 +28,11 @@ def function_to_import_path(function, override=False):
     if override:
         return function
     return "{}.{}".format(function.__module__, function.__name__)
+
+
+def get_aws_region_name():
+    region_name = boto3.session.Session().region_name
+    if not region_name:
+        region_name = 'us-east-1'
+
+    return region_name

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -18,14 +18,17 @@ except ImportError:
 
 import boto3
 
-from pyqs.utils import decode_message
+from pyqs.utils import get_aws_region_name, decode_message
 
 MESSAGE_DOWNLOAD_BATCH_SIZE = 10
 LONG_POLLING_INTERVAL = 20
 logger = logging.getLogger("pyqs")
 
 
-def get_conn(region='us-east-1', access_key_id=None, secret_access_key=None):
+def get_conn(region=None, access_key_id=None, secret_access_key=None):
+    if not region:
+        region = get_aws_region_name()
+
     return boto3.client(
         "sqs",
         aws_access_key_id=access_key_id,
@@ -232,7 +235,7 @@ class ProcessWorker(BaseWorker):
 class ManagerWorker(object):
 
     def __init__(self, queue_prefixes, worker_concurrency, interval, batchsize,
-                 prefetch_multiplier=2, region='us-east-1', access_key_id=None,
+                 prefetch_multiplier=2, region=None, access_key_id=None,
                  secret_access_key=None):
         self.connection_args = {
             "region": region,


### PR DESCRIPTION
Fix #26 

## Problem

Currently, PySQ honors AWS region configure by `.aws/config` or environment variable `AWS_DEFAULT_REGION` when sending message to SQS, but **does not** honor it when launched by `pysq` command. Even if the region is configured, `pysq` worker uses `us-east-1` when `--region` option is not provided.

This behavior is not good for people who use AWS regions other than `us-east-1`.

## Changes

This PR make `pyqs` worker honer the region configured by `.aws/config` or environment variable. As a fallback, it uses `us-east-1` as ever.