### PR TITLE
Change orphan child checking of parent id.

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -1,6 +1,6 @@
 coverage==4.4.1
 mock==1.0.1
-moto==1.3.4
+moto==1.3.8
 nose==1.3.0
 pre-commit==0.7.6
 sure==1.2.2

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -23,6 +23,7 @@ from pyqs.utils import get_aws_region_name, decode_message
 MESSAGE_DOWNLOAD_BATCH_SIZE = 10
 LONG_POLLING_INTERVAL = 20
 logger = logging.getLogger("pyqs")
+INITIAL_PID = os.getpid()
 
 
 def get_conn(region=None, access_key_id=None, secret_access_key=None):
@@ -48,7 +49,7 @@ class BaseWorker(Process):
         self.should_exit.set()
 
     def parent_is_alive(self):
-        if os.getppid() == 1:
+        if os.getppid() != INITIAL_PID:
             logger.info(
                 "Parent process has gone away, exiting process {}!".format(
                     os.getpid()))

--- a/tests/test_manager_worker.py
+++ b/tests/test_manager_worker.py
@@ -100,7 +100,7 @@ def test_main_method(ManagerWorker):
 
     ManagerWorker.assert_called_once_with(
         ['email1', 'email2'], 2, 1, 10, prefetch_multiplier=2,
-        region='us-east-1', secret_access_key=None, access_key_id=None,
+        region=None, secret_access_key=None, access_key_id=None,
     )
     ManagerWorker.return_value.start.assert_called_once_with()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -314,7 +314,7 @@ def test_worker_processes_tasks_and_logs_warning_correctly():
     logger.handlers[0].messages['error'][0].lower().should.contain(
         msg1.lower())
     msg2 = (
-        'raise ValueError("Need to be given basestring, was given '
+        '"Need to be given basestring, was given '
         '{}".format(message))\nValueError: Need to be given basestring, '
         'was given 23'
     )  # noqa
@@ -344,6 +344,7 @@ def test_parent_process_death(os):
     worker.parent_is_alive().should.be.false
 
 
+@patch("pyqs.worker.INITIAL_PID", 1234)
 @patch("pyqs.worker.os")
 def test_parent_process_alive(os):
     """
@@ -355,6 +356,7 @@ def test_parent_process_alive(os):
     worker.parent_is_alive().should.be.true
 
 
+@patch("pyqs.worker.INITIAL_PID", 1234)
 @mock_sqs
 @patch("pyqs.worker.os")
 def test_read_worker_with_parent_process_alive_and_should_not_exit(os):
@@ -429,6 +431,7 @@ def test_read_worker_with_parent_process_dead_and_should_not_exit(os):
     worker.run().should.be.none
 
 
+@patch("pyqs.worker.INITIAL_PID", 1234)
 @mock_sqs
 @patch("pyqs.worker.os")
 def test_process_worker_with_parent_process_alive_and_should_not_exit(os):
@@ -486,11 +489,16 @@ def test_process_worker_with_parent_process_alive_and_should_exit(os):
     worker.run().should.be.none
 
 
+@patch("pyqs.worker.INITIAL_PID", 1234)
 @mock_sqs
-def test_worker_processes_shuts_down_after_processing_its_max_number_of_msgs():
+@patch("pyqs.worker.os")
+def test_worker_processes_shuts_down_after_processing_its_max_number_of_msgs(
+        os):
     """
     Test worker processes shutdown after processing maximum number of messages
     """
+    os.getppid.return_value = 1234
+
     # Setup SQS Queue
     conn = boto3.client('sqs', region_name='us-east-1')
     queue_url = conn.create_queue(QueueName="tester")['QueueUrl']


### PR DESCRIPTION
We have logic for the child processes that runs to ensure the
parent hasnt died and they have become orphans. This previously
checked if the parent id was 1 and then assume the orphan should
eliminate itself because the parent has gone away. This logic
does not work in a container-based world because the parent id
could very well have a process id of 1. This resulted in the
childrend immediately eliminating themselves. This fix is to store
the parent id on startup and change the logic for orhpan checking
to see if the childs parent id is different than it was on startup.

Closes https://github.com/spulec/PyQS/issues/58