### PR TITLE
Make long polling interval a command line parameter option

### DIFF
--- a/pyqs/__init__.py
+++ b/pyqs/__init__.py
@@ -1,4 +1,4 @@
 from .decorator import task  # noqa
 
 __title__ = 'pyqs'
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -107,6 +107,15 @@ Run PyQS workers for the given queues
         action="store",
     )
 
+    parser.add_argument(
+        "--long-polling-interval",
+        dest="long_polling_interval",
+        type=int,
+        default=10,
+        help='How long to poll SQS for a new message.',
+        action="store",
+    )
+
     args = parser.parse_args()
 
     _main(
@@ -118,7 +127,8 @@ Run PyQS workers for the given queues
         secret_access_key=args.secret_access_key,
         interval=args.interval,
         batchsize=args.batchsize,
-        prefetch_multiplier=args.prefetch_multiplier
+        prefetch_multiplier=args.prefetch_multiplier,
+        long_polling_interval=args.long_polling_interval
     )
 
 
@@ -130,7 +140,7 @@ def _add_cwd_to_path():
 
 def _main(queue_prefixes, concurrency=5, logging_level="WARN",
           region=None, access_key_id=None, secret_access_key=None,
-          interval=1, batchsize=10, prefetch_multiplier=2):
+          interval=1, batchsize=10, prefetch_multiplier=2, long_polling_interval=10):
     logging.basicConfig(
         format="[%(levelname)s]: %(message)s",
         level=getattr(logging, logging_level),
@@ -138,8 +148,8 @@ def _main(queue_prefixes, concurrency=5, logging_level="WARN",
     logger.info("Starting PyQS version {}".format(__version__))
     manager = ManagerWorker(
         queue_prefixes, concurrency, interval, batchsize,
-        prefetch_multiplier=prefetch_multiplier, region=region,
-        access_key_id=access_key_id, secret_access_key=secret_access_key,
+        prefetch_multiplier=prefetch_multiplier, long_polling_interval=long_polling_interval,
+        region=region, access_key_id=access_key_id, secret_access_key=secret_access_key,
     )
     _add_cwd_to_path()
     manager.start()

--- a/tests/test_manager_worker.py
+++ b/tests/test_manager_worker.py
@@ -100,6 +100,7 @@ def test_main_method(ManagerWorker):
 
     ManagerWorker.assert_called_once_with(
         ['email1', 'email2'], 2, 1, 10, prefetch_multiplier=2,
+        long_polling_interval=10,
         region=None, secret_access_key=None, access_key_id=None,
     )
     ManagerWorker.return_value.start.assert_called_once_with()
@@ -116,12 +117,13 @@ def test_real_main_method(ArgumentParser, _main):
     ArgumentParser.return_value.parse_args.return_value = Mock(
         concurrency=3, queues=["email1"], interval=1, batchsize=10,
         logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        long_polling_interval=3,
         access_key_id=None, secret_access_key=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=10,
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=10, long_polling_interval=3,
         logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
         access_key_id=None, secret_access_key=None,
     )
@@ -288,7 +290,6 @@ def test_master_handles_signals(sys):
     sys.exit.assert_called_once_with(0)
 
 
-@patch("pyqs.worker.LONG_POLLING_INTERVAL", 3)
 @mock_sqs
 @mock_sqs_deprecated
 def test_master_shuts_down_busy_read_workers():
@@ -338,7 +339,7 @@ def test_master_shuts_down_busy_read_workers():
     # Setup Manager
     manager = ManagerWorker(
         queue_prefixes=["tester"], worker_concurrency=0, interval=0.0,
-        batchsize=1,
+        batchsize=1, long_polling_interval=3
     )
     manager.start()
 


### PR DESCRIPTION
Also lowers the default polling interval to 10, 20 is just a long time to wait, and leads to shutdowns taking a long time.

Fixes #60 