### PR TITLE
Let tasks change visibility timeout

### DIFF
--- a/pyqs/__init__.py
+++ b/pyqs/__init__.py
@@ -1,4 +1,4 @@
 from .decorator import task  # noqa
 
 __title__ = 'pyqs'
-__version__ = '0.1.2'
+__version__ = '0.1.4'

--- a/pyqs/decorator.py
+++ b/pyqs/decorator.py
@@ -54,6 +54,11 @@ def task_delayer(func_to_delay, queue_name, delay_seconds=None,
 
 
 class task(object):
+    """ Decorator that enables sqs based task execution. If the function
+    accepts an optional `_context` argument, an instance of TaskContext is
+    passed to the task function. The context allows the function to do things
+    like change message visibility. """
+
     def __init__(self, queue=None, delay_seconds=None,
                  custom_function_path=None):
         self.queue_name = queue

--- a/pyqs/utils.py
+++ b/pyqs/utils.py
@@ -3,6 +3,7 @@ import json
 import pickle
 
 import boto3
+from datetime import timedelta
 
 
 def decode_message(message):
@@ -36,3 +37,20 @@ def get_aws_region_name():
         region_name = 'us-east-1'
 
     return region_name
+
+
+class TaskContext(object):
+    """ Tasks may optionally accept a _context variable. If they do, an
+     instance of this object is passed as the context. """
+
+    def __init__(self, conn, queue_url, receipt_handle):
+        self.conn = conn
+        self.queue_url = queue_url
+        self.receipt_handle = receipt_handle
+
+    def change_message_visibility(self, timeout=timedelta(minutes=10)):
+        self.conn.change_message_visibility(
+            QueueUrl=self.queue_url,
+            ReceiptHandle=self.receipt_handle,
+            VisibilityTimeout=int(timeout.total_seconds())
+        )


### PR DESCRIPTION
Allow tasks to change the visibility timeout of the message they are handling.
When a task fails, immediately make it available again instead of waiting for visibility timeout.

Fixes https://github.com/spulec/PyQS/issues/47