### PR TITLE
Replace time.clock() with time.time() for wider Python compatibility

### DIFF
--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -200,10 +200,10 @@ class ProcessWorker(BaseWorker):
             )
             return True
         try:
-            start_time = time.clock()
+            start_time = time.time()
             task(*args, **kwargs)
         except Exception:
-            end_time = time.clock()
+            end_time = time.time()
             logger.exception(
                 "Task {} raised error in {:.4f} seconds: with args: {} "
                 "and kwargs: {}: {}".format(
@@ -216,7 +216,7 @@ class ProcessWorker(BaseWorker):
             )
             return True
         else:
-            end_time = time.clock()
+            end_time = time.time()
             self.conn.delete_message(
                 QueueUrl=queue_url,
                 ReceiptHandle=message['ReceiptHandle']


### PR DESCRIPTION
`time.clock()` was removed in Python 3.8 after it was marked as deprecated in
Python 3.3. Switch to using `time.time()` as it is supported in Python 2.7,
compared to `time.monotonic()` which is only available from Python 3.3.