### PR TITLE
Feature/add pre and post process hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/*
 *.egg-info/*
 build/*
 htmlcov/*
+.idea/*
 *~
 *#
 

--- a/pyqs/decorator.py
+++ b/pyqs/decorator.py
@@ -54,21 +54,11 @@ def task_delayer(func_to_delay, queue_name, delay_seconds=None,
 
 
 class task(object):
-    _hooks = {}
-
     def __init__(self, queue=None, delay_seconds=None,
-                 custom_function_path=None, hooks=None):
+                 custom_function_path=None):
         self.queue_name = queue
         self.delay_seconds = delay_seconds
         self.function_path = custom_function_path
-
-    @classmethod
-    def set_hooks(self, hooks):
-        self._hooks = hooks
-
-    @classmethod
-    def get_hooks(self):
-        return self._hooks
 
     def __call__(self, *args, **kwargs):
         func_to_wrap = args[0]
@@ -79,6 +69,4 @@ class task(object):
             function = self.function_path
         func_to_wrap.delay = task_delayer(
             function, self.queue_name, self.delay_seconds, override=override)
-        func_to_wrap.pre_process_hook = self.get_hooks().get("pre_process")
-        func_to_wrap.post_process_hook = self.get_hooks().get("post_process")
         return func_to_wrap

--- a/pyqs/decorator.py
+++ b/pyqs/decorator.py
@@ -54,11 +54,21 @@ def task_delayer(func_to_delay, queue_name, delay_seconds=None,
 
 
 class task(object):
+    _hooks = {}
+
     def __init__(self, queue=None, delay_seconds=None,
-                 custom_function_path=None):
+                 custom_function_path=None, hooks=None):
         self.queue_name = queue
         self.delay_seconds = delay_seconds
         self.function_path = custom_function_path
+
+    @classmethod
+    def set_hooks(self, hooks):
+        self._hooks = hooks
+
+    @classmethod
+    def get_hooks(self):
+        return self._hooks
 
     def __call__(self, *args, **kwargs):
         func_to_wrap = args[0]
@@ -69,4 +79,6 @@ class task(object):
             function = self.function_path
         func_to_wrap.delay = task_delayer(
             function, self.queue_name, self.delay_seconds, override=override)
+        func_to_wrap.pre_process_hook = self.get_hooks().get("pre_process")
+        func_to_wrap.post_process_hook = self.get_hooks().get("post_process")
         return func_to_wrap

--- a/pyqs/events.py
+++ b/pyqs/events.py
@@ -1,19 +1,41 @@
+"""
+pyqs events registry: register callback functions on pyqs events
+
+Usage:
+from pyqs.events import register_event
+
+register_event("pre_process", lambda context: print(context))
+"""
+
+
 class Events:
     def __init__(self):
         self.pre_process = []
         self.post_process = []
 
+    def clear(self):
+        self.pre_process = []
+        self.post_process = []
 
-# Singleton
-EVENTS = Events()
+
+# Global singleton
+_EVENTS = Events()
 
 
-def register(name, callback):
-    if hasattr(EVENTS, name):
-        getattr(EVENTS, name).append(callback)
+class NoEventException(Exception):
+    pass
+
+
+def register_event(name, callback):
+    if hasattr(_EVENTS, name):
+        getattr(_EVENTS, name).append(callback)
     else:
-        raise Exception(f"{name} is not a valid pyqs event.")
+        raise NoEventException(f"{name} is not a valid pyqs event.")
 
 
 def get_events():
-    return EVENTS
+    return _EVENTS
+
+
+def clear_events():
+    _EVENTS.clear()

--- a/pyqs/events.py
+++ b/pyqs/events.py
@@ -1,0 +1,19 @@
+class Events:
+    def __init__(self):
+        self.pre_process = []
+        self.post_process = []
+
+
+# Singleton
+EVENTS = Events()
+
+
+def register(name, callback):
+    if hasattr(EVENTS, name):
+        getattr(EVENTS, name).append(callback)
+    else:
+        raise Exception(f"{name} is not a valid pyqs event.")
+
+
+def get_events():
+    return EVENTS

--- a/pyqs/events.py
+++ b/pyqs/events.py
@@ -30,7 +30,9 @@ def register_event(name, callback):
     if hasattr(_EVENTS, name):
         getattr(_EVENTS, name).append(callback)
     else:
-        raise NoEventException(f"{name} is not a valid pyqs event.")
+        raise NoEventException(
+            "{name} is not a valid pyqs event.".format(name=name)
+        )
 
 
 def get_events():

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -200,7 +200,8 @@ class ProcessWorker(BaseWorker):
             "timeout": timeout
         }
 
-        # Modify the contexts separately so the original context isn't modified by later processing
+        # Modify the contexts separately so the original
+        # context isn't modified by later processing
         post_process_context = copy.copy(pre_process_context)
 
         current_time = time.time()

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -36,3 +36,8 @@ def delayed_task():
 @task(custom_function_path="custom_function.path", queue="foobar")
 def custom_path_task():
     pass
+
+
+@task()
+def exception_task(message, extra=None):
+    raise Exception('this task raises an exception!')

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,16 +1,6 @@
-from functools import wraps
 from nose.tools import assert_raises
 from pyqs import events
-
-
-def clear_events_registry(fn):
-    """Clear the global events registry before each test."""
-
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        events.clear_events()
-        return fn(*args, **kwargs)
-    return wrapper
+from tests.utils import clear_events_registry
 
 
 @clear_events_registry

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -22,7 +22,9 @@ def test_register_multiple_same_events():
 
     events.register_event("pre_process", print_pre_process)
     events.register_event("pre_process", print_numbers)
-    events.get_events().pre_process.should.equal([print_pre_process, print_numbers])
+    events.get_events().pre_process.should.equal([
+        print_pre_process, print_numbers
+    ])
 
 
 @clear_events_registry
@@ -54,11 +56,20 @@ def test_register_multiple_different_events():
     events.register_event("pre_process", print_numbers)
     events.register_event("post_process", print_post_process)
     events.register_event("post_process", print_numbers)
-    events.get_events().pre_process.should.equal([print_pre_process, print_numbers])
-    events.get_events().post_process.should.equal([print_post_process, print_numbers])
+    events.get_events().pre_process.should.equal([
+        print_pre_process, print_numbers
+    ])
+    events.get_events().post_process.should.equal([
+        print_post_process, print_numbers
+    ])
 
 
 @clear_events_registry
 def test_register_non_existent_event():
     non_existent_event = "non_existent_event"
-    assert_raises(events.NoEventException, events.register_event, non_existent_event, lambda x: x)
+    assert_raises(
+        events.NoEventException,
+        events.register_event,
+        non_existent_event,
+        lambda x: x
+    )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,74 @@
+from functools import wraps
+from nose.tools import assert_raises
+from pyqs import events
+
+
+def clear_events_registry(fn):
+    """Clear the global events registry before each test."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        events.clear_events()
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+@clear_events_registry
+def test_register_event():
+    def print_pre_process(context):
+        print(context)
+
+    events.register_event("pre_process", print_pre_process)
+    events.get_events().pre_process.should.equal([print_pre_process])
+
+
+@clear_events_registry
+def test_register_multiple_same_events():
+    def print_pre_process(context):
+        print(context)
+
+    def print_numbers(context):
+        print(1 + 2)
+
+    events.register_event("pre_process", print_pre_process)
+    events.register_event("pre_process", print_numbers)
+    events.get_events().pre_process.should.equal([print_pre_process, print_numbers])
+
+
+@clear_events_registry
+def test_register_different_events():
+    def print_pre_process(context):
+        print(context)
+
+    def print_post_process(context):
+        print(context)
+
+    events.register_event("pre_process", print_pre_process)
+    events.register_event("post_process", print_post_process)
+    events.get_events().pre_process.should.equal([print_pre_process])
+    events.get_events().post_process.should.equal([print_post_process])
+
+
+@clear_events_registry
+def test_register_multiple_different_events():
+    def print_pre_process(context):
+        print(context)
+
+    def print_post_process(context):
+        print(context)
+
+    def print_numbers(context):
+        print(1 + 2)
+
+    events.register_event("pre_process", print_pre_process)
+    events.register_event("pre_process", print_numbers)
+    events.register_event("post_process", print_post_process)
+    events.register_event("post_process", print_numbers)
+    events.get_events().pre_process.should.equal([print_pre_process, print_numbers])
+    events.get_events().post_process.should.equal([print_post_process, print_numbers])
+
+
+@clear_events_registry
+def test_register_non_existent_event():
+    non_existent_event = "non_existent_event"
+    assert_raises(events.NoEventException, events.register_event, non_existent_event, lambda x: x)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -736,27 +736,35 @@ def test_worker_processes_tasks_with_pre_process_callback():
     Test worker runs registered callbacks when processing a message
     """
 
-    # Declare this so it can be checked as a side effect to pre_process_with_side_effect
-    pre_process_context = None
+    # Declare this so it can be checked as a side effect
+    # to pre_process_with_side_effect
+    contexts = []
 
     def pre_process_with_side_effect(context):
-        nonlocal pre_process_context
-        pre_process_context = context
+        contexts.append(context)
 
     # When we have a registered pre_process callback
     register_event("pre_process", pre_process_with_side_effect)
 
     # And we process a message
-    internal_queue = _add_message_to_internal_queue('tests.tasks.index_incrementer')
+    internal_queue = _add_message_to_internal_queue(
+        'tests.tasks.index_incrementer'
+    )
     worker = ProcessWorker(internal_queue, INTERVAL, parent_id=1)
     worker.process_message()
+
+    pre_process_context = contexts[0]
 
     # We should run the callback with the task context
     pre_process_context['task_name'].should.equal('index_incrementer')
     pre_process_context['args'].should.equal([])
     pre_process_context['kwargs'].should.equal({'message': 'Test message'})
-    pre_process_context['full_task_path'].should.equal('tests.tasks.index_incrementer')
-    pre_process_context['queue_url'].should.equal('https://queue.amazonaws.com/123456789012/tester')
+    pre_process_context['full_task_path'].should.equal(
+        'tests.tasks.index_incrementer'
+    )
+    pre_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
     pre_process_context['timeout'].should.equal(30)
 
     assert 'fetch_time' in pre_process_context
@@ -770,30 +778,39 @@ def test_worker_processes_tasks_with_pre_process_callback():
 @mock_sqs
 def test_worker_processes_tasks_with_post_process_callback_success():
     """
-    Test worker runs registered callbacks when processing a message and it succeeds
+    Test worker runs registered callbacks when
+    processing a message and it succeeds
     """
 
-    # Declare this so it can be checked as a side effect to post_process_with_side_effect
-    post_process_context = None
+    # Declare this so it can be checked as a side effect
+    # to post_process_with_side_effect
+    contexts = []
 
     def post_process_with_side_effect(context):
-        nonlocal post_process_context
-        post_process_context = context
+        contexts.append(context)
 
     # When we have a registered post_process callback
     register_event("post_process", post_process_with_side_effect)
 
     # And we process a message
-    internal_queue = _add_message_to_internal_queue('tests.tasks.index_incrementer')
+    internal_queue = _add_message_to_internal_queue(
+        'tests.tasks.index_incrementer'
+    )
     worker = ProcessWorker(internal_queue, INTERVAL, parent_id=1)
     worker.process_message()
+
+    post_process_context = contexts[0]
 
     # We should run the callback with the task context
     post_process_context['task_name'].should.equal('index_incrementer')
     post_process_context['args'].should.equal([])
     post_process_context['kwargs'].should.equal({'message': 'Test message'})
-    post_process_context['full_task_path'].should.equal('tests.tasks.index_incrementer')
-    post_process_context['queue_url'].should.equal('https://queue.amazonaws.com/123456789012/tester')
+    post_process_context['full_task_path'].should.equal(
+        'tests.tasks.index_incrementer'
+    )
+    post_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
     post_process_context['timeout'].should.equal(30)
     post_process_context['status'].should.equal('success')
 
@@ -808,30 +825,39 @@ def test_worker_processes_tasks_with_post_process_callback_success():
 @mock_sqs
 def test_worker_processes_tasks_with_post_process_callback_exception():
     """
-    Test worker runs registered callbacks when processing a message and it fails
+    Test worker runs registered callbacks when processing
+    a message and it fails
     """
 
-    # Declare this so it can be checked as a side effect to post_process_with_side_effect
-    post_process_context = None
+    # Declare this so it can be checked as a side effect
+    # to post_process_with_side_effect
+    contexts = []
 
     def post_process_with_side_effect(context):
-        nonlocal post_process_context
-        post_process_context = context
+        contexts.append(context)
 
     # When we have a registered post_process callback
     register_event("post_process", post_process_with_side_effect)
 
     # And we process a message
-    internal_queue = _add_message_to_internal_queue('tests.tasks.exception_task')
+    internal_queue = _add_message_to_internal_queue(
+        'tests.tasks.exception_task'
+    )
     worker = ProcessWorker(internal_queue, INTERVAL, parent_id=1)
     worker.process_message()
+
+    post_process_context = contexts[0]
 
     # We should run the callback with the task context
     post_process_context['task_name'].should.equal('exception_task')
     post_process_context['args'].should.equal([])
     post_process_context['kwargs'].should.equal({'message': 'Test message'})
-    post_process_context['full_task_path'].should.equal('tests.tasks.exception_task')
-    post_process_context['queue_url'].should.equal('https://queue.amazonaws.com/123456789012/tester')
+    post_process_context['full_task_path'].should.equal(
+        'tests.tasks.exception_task'
+    )
+    post_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
     post_process_context['timeout'].should.equal(30)
     post_process_context['status'].should.equal('exception')
 
@@ -850,42 +876,53 @@ def test_worker_processes_tasks_with_pre_and_post_process():
     """
 
     # Declare these so they can be checked as a side effect to the callbacks
-    pre_process_context = None
-    post_process_context = None
+    contexts = []
 
     def pre_process_with_side_effect(context):
-        nonlocal pre_process_context
-        pre_process_context = context
+        contexts.append(context)
 
     def post_process_with_side_effect(context):
-        nonlocal post_process_context
-        post_process_context = context
+        contexts.append(context)
 
     # When we have a registered pre_process and post_process callback
     register_event("pre_process", pre_process_with_side_effect)
     register_event("post_process", post_process_with_side_effect)
 
     # And we process a message
-    internal_queue = _add_message_to_internal_queue('tests.tasks.index_incrementer')
+    internal_queue = _add_message_to_internal_queue(
+        'tests.tasks.index_incrementer'
+    )
     worker = ProcessWorker(internal_queue, INTERVAL, parent_id=1)
     worker.process_message()
+
+    pre_process_context = contexts[0]
 
     # We should run the callbacks with the right task contexts
     pre_process_context['task_name'].should.equal('index_incrementer')
     pre_process_context['args'].should.equal([])
     pre_process_context['kwargs'].should.equal({'message': 'Test message'})
-    pre_process_context['full_task_path'].should.equal('tests.tasks.index_incrementer')
-    pre_process_context['queue_url'].should.equal('https://queue.amazonaws.com/123456789012/tester')
+    pre_process_context['full_task_path'].should.equal(
+        'tests.tasks.index_incrementer'
+    )
+    pre_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
     pre_process_context['timeout'].should.equal(30)
 
     assert 'fetch_time' in pre_process_context
     assert 'status' not in pre_process_context
 
+    post_process_context = contexts[1]
+
     post_process_context['task_name'].should.equal('index_incrementer')
     post_process_context['args'].should.equal([])
     post_process_context['kwargs'].should.equal({'message': 'Test message'})
-    post_process_context['full_task_path'].should.equal('tests.tasks.index_incrementer')
-    post_process_context['queue_url'].should.equal('https://queue.amazonaws.com/123456789012/tester')
+    post_process_context['full_task_path'].should.equal(
+        'tests.tasks.index_incrementer'
+    )
+    post_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
     post_process_context['timeout'].should.equal(30)
     post_process_context['status'].should.equal('success')
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,8 +2,11 @@
 from __future__ import unicode_literals
 
 import logging
+from functools import wraps
 
 from threading import Thread
+
+from pyqs import events
 
 
 class MockLoggingHandler(logging.Handler):
@@ -55,3 +58,13 @@ class ThreadWithReturnValue3(Thread):
     def join(self):
         Thread.join(self)
         return self._return
+
+
+def clear_events_registry(fn):
+    """Clear the global events registry before each test."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        events.clear_events()
+        return fn(*args, **kwargs)
+    return wrapper


### PR DESCRIPTION
This is a proof of concept for https://github.com/spulec/PyQS/issues/70

I haven't figured out how best to test this, it might require a more end-to-end test.

Works like:
```python
from pyqs import task

def print_pre_process(context):
    print({"pre_process": context})

def print_post_process(context):
    print({"pre_process": context})

task.set_hooks({"pre_process": print_pre_process, "post_process": print_post_process})

@task(queue="my_queue")
def send_email(subject):
    pass
```

```
pyqs email.tasks.send_email
# {"pre_process": {"task_name": "send_email", ...}}
# {"post_process": {"task_name": "send_email", "status": "success", ...}}
```