### PR TITLE
Feature/simple process worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -7,10 +7,13 @@ import os
 import sys
 from argparse import ArgumentParser
 
-from .worker import ManagerWorker, SimpleManagerWorker
+from .worker import ManagerWorker, BaseManager
 from . import __version__
 
 logger = logging.getLogger("pyqs")
+
+SIMPLE_WORKER_DEFAULT_BATCH_SIZE = 1
+DEFAULT_BATCH_SIZE = 10
 
 
 def _set_batchsize(args):
@@ -21,10 +24,10 @@ def _set_batchsize(args):
     simple_worker = args.simple_worker
     if simple_worker:
         # Default batchsize for SimpleProcessWorker
-        return 1
+        return SIMPLE_WORKER_DEFAULT_BATCH_SIZE
 
     # Default batchsize for ProcessWorker
-    return 10
+    return DEFAULT_BATCH_SIZE
 
 
 def main():
@@ -152,7 +155,7 @@ def _add_cwd_to_path():
 
 def _main(queue_prefixes, concurrency=5, logging_level="WARN",
           region=None, access_key_id=None, secret_access_key=None,
-          interval=1, batchsize=10, prefetch_multiplier=2,
+          interval=1, batchsize=DEFAULT_BATCH_SIZE, prefetch_multiplier=2,
           simple_worker=False):
     logging.basicConfig(
         format="[%(levelname)s]: %(message)s",
@@ -161,7 +164,7 @@ def _main(queue_prefixes, concurrency=5, logging_level="WARN",
     logger.info("Starting PyQS version {}".format(__version__))
 
     if simple_worker:
-        manager = SimpleManagerWorker(
+        manager = BaseManager(
             queue_prefixes, concurrency, batchsize,
             region=region, access_key_id=access_key_id,
             secret_access_key=secret_access_key,

--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -7,7 +7,7 @@ import os
 import sys
 from argparse import ArgumentParser
 
-from .worker import ManagerWorker, BaseManager
+from .worker import ManagerWorker, SimpleManagerWorker
 from . import __version__
 
 logger = logging.getLogger("pyqs")
@@ -164,7 +164,7 @@ def _main(queue_prefixes, concurrency=5, logging_level="WARN",
     logger.info("Starting PyQS version {}".format(__version__))
 
     if simple_worker:
-        manager = BaseManager(
+        manager = SimpleManagerWorker(
             queue_prefixes, concurrency, batchsize,
             region=region, access_key_id=access_key_id,
             secret_access_key=secret_access_key,

--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -165,7 +165,7 @@ def _main(queue_prefixes, concurrency=5, logging_level="WARN",
 
     if simple_worker:
         manager = SimpleManagerWorker(
-            queue_prefixes, concurrency, batchsize,
+            queue_prefixes, concurrency, interval, batchsize,
             region=region, access_key_id=access_key_id,
             secret_access_key=secret_access_key,
         )

--- a/pyqs/main.py
+++ b/pyqs/main.py
@@ -13,6 +13,20 @@ from . import __version__
 logger = logging.getLogger("pyqs")
 
 
+def _set_batchsize(args):
+    batchsize = args.batchsize
+    if batchsize:
+        return batchsize
+
+    simple_worker = args.simple_worker
+    if simple_worker:
+        # Default batchsize for SimpleProcessWorker
+        return 1
+
+    # Default batchsize for ProcessWorker
+    return 10
+
+
 def main():
     parser = ArgumentParser(description="""
 Run PyQS workers for the given queues
@@ -90,7 +104,7 @@ Run PyQS workers for the given queues
         "--batchsize",
         dest="batchsize",
         type=int,
-        default=10,
+        default=None,
         help='How many messages to download at a time from SQS.',
         action="store",
     )
@@ -124,7 +138,7 @@ Run PyQS workers for the given queues
         access_key_id=args.access_key_id,
         secret_access_key=args.secret_access_key,
         interval=args.interval,
-        batchsize=args.batchsize,
+        batchsize=_set_batchsize(args),
         prefetch_multiplier=args.prefetch_multiplier,
         simple_worker=args.simple_worker
     )

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -69,6 +69,11 @@ class BaseWorker(Process):
             return False
         return True
 
+    def _run_hooks(self, hook_name, context):
+        hooks = getattr(get_events(), hook_name)
+        for hook in hooks:
+            hook(context)
+
 
 class ReadWorker(BaseWorker):
 
@@ -261,11 +266,6 @@ class ProcessWorker(BaseWorker):
             self._run_hooks("post_process", post_process_context)
         return True
 
-    def _run_hooks(self, hook_name, context):
-        hooks = getattr(get_events(), hook_name)
-        for hook in hooks:
-            hook(context)
-
 
 class SimpleProcessWorker(BaseWorker):
 
@@ -394,11 +394,6 @@ class SimpleProcessWorker(BaseWorker):
             post_process_context["status"] = "success"
             self._run_hooks("post_process", post_process_context)
         self.messages_processed += 1
-
-    def _run_hooks(self, hook_name, context):
-        hooks = getattr(get_events(), hook_name)
-        for hook in hooks:
-            hook(context)
 
 
 class BaseManager(object):

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -401,6 +401,133 @@ class SimpleProcessWorker(BaseWorker):
             hook(context)
 
 
+class BaseManager(object):
+
+    def __init__(self, queue_prefixes, worker_concurrency, batchsize,
+                 region=None, access_key_id=None,
+                 secret_access_key=None):
+        self.connection_args = {
+            "region": region,
+            "access_key_id": access_key_id,
+            "secret_access_key": secret_access_key,
+        }
+        self.batchsize = batchsize
+        if batchsize > MESSAGE_DOWNLOAD_BATCH_SIZE:
+            self.batchsize = MESSAGE_DOWNLOAD_BATCH_SIZE
+        if batchsize <= 0:
+            self.batchsize = 1
+        self.queue_prefixes = queue_prefixes
+        self.queue_urls = self.get_queue_urls_from_queue_prefixes(
+            self.queue_prefixes)
+        self.worker_children = []
+        self._pid = os.getpid()
+        self._initialize_worker_children(worker_concurrency)
+        self._running = True
+        self._register_signals()
+
+    def _register_signals(self):
+        for SIG in [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT,
+                    signal.SIGHUP]:
+            self.register_shutdown_signal(SIG)
+
+    def _initialize_worker_children(self, number):
+        for queue_url in self.queue_urls:
+            for index in range(number):
+                self.worker_children.append(
+                    SimpleProcessWorker(
+                        queue_url, self.batchsize,
+                        connection_args=self.connection_args,
+                        parent_id=self._pid,
+                    )
+                )
+
+    def get_queue_urls_from_queue_prefixes(self, queue_prefixes):
+        conn = get_conn(**self.connection_args)
+        queue_urls = conn.list_queues().get('QueueUrls', [])
+        matching_urls = []
+
+        logger.info("Loading Queues:")
+        for prefix in queue_prefixes:
+            logger.info("[Queue]\t{}".format(prefix))
+            matching_urls.extend([
+                queue_url for queue_url in queue_urls if
+                fnmatch.fnmatch(queue_url.rsplit("/", 1)[1], prefix)
+            ])
+        logger.info("Found matching SQS Queues: {}".format(matching_urls))
+        return matching_urls
+
+    def check_for_new_queues(self):
+        queue_urls = self.get_queue_urls_from_queue_prefixes(
+            self.queue_prefixes)
+        new_queue_urls = set(queue_urls) - set(self.queue_urls)
+        for new_queue_url in new_queue_urls:
+            logger.info("Found new queue\t{}".format(new_queue_url))
+            worker = SimpleProcessWorker(
+                new_queue_url, self.batchsize,
+                connection_args=self.connection_args,
+                parent_id=self._pid,
+            )
+            worker.start()
+            self.worker_children.append(worker)
+
+    def start(self):
+        for child in self.worker_children:
+            child.start()
+
+    def stop(self):
+        for child in self.worker_children:
+            child.shutdown()
+        for child in self.worker_children:
+            child.join()
+
+    def sleep(self):
+        counter = 0
+        while self._running:
+            counter = counter + 1
+            if counter % 1000 == 0:
+                self.process_counts()
+                self.replace_workers()
+            if counter % 30000 == 0:
+                counter = 0
+                self.check_for_new_queues()
+            time.sleep(0.001)
+        self._exit()
+
+    def register_shutdown_signal(self, SIG):
+        signal.signal(SIG, self._graceful_shutdown)
+
+    def _graceful_shutdown(self, signum, frame):
+        logger.info('Received shutdown signal %s', signum)
+        self._running = False
+
+    def _exit(self):
+        logger.info('Graceful shutdown. Sending shutdown signal to children.')
+        self.stop()
+        sys.exit(0)
+
+    def process_counts(self):
+        worker_count = sum(map(lambda x: x.is_alive(), self.worker_children))
+        logger.debug("Worker Processes: {}".format(worker_count))
+
+    def replace_workers(self):
+        self._replace_worker_children()
+
+    def _replace_worker_children(self):
+        for index, worker in enumerate(self.worker_children):
+            if not worker.is_alive():
+                logger.info(
+                    "Worker Process {} is no longer responding, "
+                    "spawning a new worker.".format(worker.pid))
+                self.worker_children.pop(index)
+                worker = SimpleProcessWorker(
+                    worker.queue_url, self.batchsize,
+                    connection_args=self.connection_args,
+                    parent_id=self._pid,
+                )
+                worker.start()
+                self.worker_children.append(worker)
+
+
 class ManagerWorker(object):
 
     def __init__(self, queue_prefixes, worker_concurrency, interval, batchsize,
@@ -565,133 +692,6 @@ class ManagerWorker(object):
                 self.worker_children.pop(index)
                 worker = ProcessWorker(
                     self.internal_queue, self.interval,
-                    connection_args=self.connection_args,
-                    parent_id=self._pid,
-                )
-                worker.start()
-                self.worker_children.append(worker)
-
-
-class SimpleManagerWorker(object):
-
-    def __init__(self, queue_prefixes, worker_concurrency, batchsize,
-                 region=None, access_key_id=None,
-                 secret_access_key=None):
-        self.connection_args = {
-            "region": region,
-            "access_key_id": access_key_id,
-            "secret_access_key": secret_access_key,
-        }
-        self.batchsize = batchsize
-        if batchsize > MESSAGE_DOWNLOAD_BATCH_SIZE:
-            self.batchsize = MESSAGE_DOWNLOAD_BATCH_SIZE
-        if batchsize <= 0:
-            self.batchsize = 1
-        self.queue_prefixes = queue_prefixes
-        self.queue_urls = self.get_queue_urls_from_queue_prefixes(
-            self.queue_prefixes)
-        self.worker_children = []
-        self._pid = os.getpid()
-        self._initialize_worker_children(worker_concurrency)
-        self._running = True
-        self._register_signals()
-
-    def _register_signals(self):
-        for SIG in [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT,
-                    signal.SIGHUP]:
-            self.register_shutdown_signal(SIG)
-
-    def _initialize_worker_children(self, number):
-        for queue_url in self.queue_urls:
-            for index in range(number):
-                self.worker_children.append(
-                    SimpleProcessWorker(
-                        queue_url, self.batchsize,
-                        connection_args=self.connection_args,
-                        parent_id=self._pid,
-                    )
-                )
-
-    def get_queue_urls_from_queue_prefixes(self, queue_prefixes):
-        conn = get_conn(**self.connection_args)
-        queue_urls = conn.list_queues().get('QueueUrls', [])
-        matching_urls = []
-
-        logger.info("Loading Queues:")
-        for prefix in queue_prefixes:
-            logger.info("[Queue]\t{}".format(prefix))
-            matching_urls.extend([
-                queue_url for queue_url in queue_urls if
-                fnmatch.fnmatch(queue_url.rsplit("/", 1)[1], prefix)
-            ])
-        logger.info("Found matching SQS Queues: {}".format(matching_urls))
-        return matching_urls
-
-    def check_for_new_queues(self):
-        queue_urls = self.get_queue_urls_from_queue_prefixes(
-            self.queue_prefixes)
-        new_queue_urls = set(queue_urls) - set(self.queue_urls)
-        for new_queue_url in new_queue_urls:
-            logger.info("Found new queue\t{}".format(new_queue_url))
-            worker = SimpleProcessWorker(
-                new_queue_url, self.batchsize,
-                connection_args=self.connection_args,
-                parent_id=self._pid,
-            )
-            worker.start()
-            self.worker_children.append(worker)
-
-    def start(self):
-        for child in self.worker_children:
-            child.start()
-
-    def stop(self):
-        for child in self.worker_children:
-            child.shutdown()
-        for child in self.worker_children:
-            child.join()
-
-    def sleep(self):
-        counter = 0
-        while self._running:
-            counter = counter + 1
-            if counter % 1000 == 0:
-                self.process_counts()
-                self.replace_workers()
-            if counter % 30000 == 0:
-                counter = 0
-                self.check_for_new_queues()
-            time.sleep(0.001)
-        self._exit()
-
-    def register_shutdown_signal(self, SIG):
-        signal.signal(SIG, self._graceful_shutdown)
-
-    def _graceful_shutdown(self, signum, frame):
-        logger.info('Received shutdown signal %s', signum)
-        self._running = False
-
-    def _exit(self):
-        logger.info('Graceful shutdown. Sending shutdown signal to children.')
-        self.stop()
-        sys.exit(0)
-
-    def process_counts(self):
-        worker_count = sum(map(lambda x: x.is_alive(), self.worker_children))
-        logger.debug("Worker Processes: {}".format(worker_count))
-
-    def replace_workers(self):
-        self._replace_worker_children()
-
-    def _replace_worker_children(self):
-        for index, worker in enumerate(self.worker_children):
-            if not worker.is_alive():
-                logger.info(
-                    "Worker Process {} is no longer responding, "
-                    "spawning a new worker.".format(worker.pid))
-                self.worker_children.pop(index)
-                worker = SimpleProcessWorker(
-                    worker.queue_url, self.batchsize,
                     connection_args=self.connection_args,
                     parent_id=self._pid,
                 )

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -489,6 +489,9 @@ class BaseManager(object):
     def replace_workers(self):
         self._replace_worker_children()
 
+    def _replace_worker_children(self):
+        raise NotImplementedError
+
 
 class SimpleManagerWorker(BaseManager):
 

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -594,3 +594,130 @@ class ManagerWorker(object):
                 )
                 worker.start()
                 self.worker_children.append(worker)
+
+
+class SimpleManagerWorker(object):
+
+    def __init__(self, queue_prefixes, worker_concurrency, batchsize,
+                 region=None, access_key_id=None,
+                 secret_access_key=None):
+        self.connection_args = {
+            "region": region,
+            "access_key_id": access_key_id,
+            "secret_access_key": secret_access_key,
+        }
+        self.batchsize = batchsize
+        if batchsize > MESSAGE_DOWNLOAD_BATCH_SIZE:
+            self.batchsize = MESSAGE_DOWNLOAD_BATCH_SIZE
+        if batchsize <= 0:
+            self.batchsize = 1
+        self.queue_prefixes = queue_prefixes
+        self.queue_urls = self.get_queue_urls_from_queue_prefixes(
+            self.queue_prefixes)
+        self.worker_children = []
+        self._pid = os.getpid()
+        self._initialize_worker_children(worker_concurrency)
+        self._running = True
+        self._register_signals()
+
+    def _register_signals(self):
+        for SIG in [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT,
+                    signal.SIGHUP]:
+            self.register_shutdown_signal(SIG)
+
+    def _initialize_worker_children(self, number):
+        for queue_url in self.queue_urls:
+            for index in range(number):
+                self.worker_children.append(
+                    SimpleProcessWorker(
+                        queue_url, self.batchsize,
+                        connection_args=self.connection_args,
+                        parent_id=self._pid,
+                    )
+                )
+
+    def get_queue_urls_from_queue_prefixes(self, queue_prefixes):
+        conn = get_conn(**self.connection_args)
+        queue_urls = conn.list_queues().get('QueueUrls', [])
+        matching_urls = []
+
+        logger.info("Loading Queues:")
+        for prefix in queue_prefixes:
+            logger.info("[Queue]\t{}".format(prefix))
+            matching_urls.extend([
+                queue_url for queue_url in queue_urls if
+                fnmatch.fnmatch(queue_url.rsplit("/", 1)[1], prefix)
+            ])
+        logger.info("Found matching SQS Queues: {}".format(matching_urls))
+        return matching_urls
+
+    def check_for_new_queues(self):
+        queue_urls = self.get_queue_urls_from_queue_prefixes(
+            self.queue_prefixes)
+        new_queue_urls = set(queue_urls) - set(self.queue_urls)
+        for new_queue_url in new_queue_urls:
+            logger.info("Found new queue\t{}".format(new_queue_url))
+            worker = SimpleProcessWorker(
+                new_queue_url, self.batchsize,
+                connection_args=self.connection_args,
+                parent_id=self._pid,
+            )
+            worker.start()
+            self.worker_children.append(worker)
+
+    def start(self):
+        for child in self.worker_children:
+            child.start()
+
+    def stop(self):
+        for child in self.worker_children:
+            child.shutdown()
+        for child in self.worker_children:
+            child.join()
+
+    def sleep(self):
+        counter = 0
+        while self._running:
+            counter = counter + 1
+            if counter % 1000 == 0:
+                self.process_counts()
+                self.replace_workers()
+            if counter % 30000 == 0:
+                counter = 0
+                self.check_for_new_queues()
+            time.sleep(0.001)
+        self._exit()
+
+    def register_shutdown_signal(self, SIG):
+        signal.signal(SIG, self._graceful_shutdown)
+
+    def _graceful_shutdown(self, signum, frame):
+        logger.info('Received shutdown signal %s', signum)
+        self._running = False
+
+    def _exit(self):
+        logger.info('Graceful shutdown. Sending shutdown signal to children.')
+        self.stop()
+        sys.exit(0)
+
+    def process_counts(self):
+        worker_count = sum(map(lambda x: x.is_alive(), self.worker_children))
+        logger.debug("Worker Processes: {}".format(worker_count))
+
+    def replace_workers(self):
+        self._replace_worker_children()
+
+    def _replace_worker_children(self):
+        for index, worker in enumerate(self.worker_children):
+            if not worker.is_alive():
+                logger.info(
+                    "Worker Process {} is no longer responding, "
+                    "spawning a new worker.".format(worker.pid))
+                self.worker_children.pop(index)
+                worker = SimpleProcessWorker(
+                    worker.queue_url, self.batchsize,
+                    connection_args=self.connection_args,
+                    parent_id=self._pid,
+                )
+                worker.start()
+                self.worker_children.append(worker)

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -481,9 +481,6 @@ class BaseManager(object):
         raise NotImplementedError
 
     def replace_workers(self):
-        self._replace_worker_children()
-
-    def _replace_worker_children(self):
         raise NotImplementedError
 
 
@@ -538,7 +535,7 @@ class SimpleManagerWorker(BaseManager):
         worker_count = sum(map(lambda x: x.is_alive(), self.worker_children))
         logger.debug("Worker Processes: {}".format(worker_count))
 
-    def _replace_worker_children(self):
+    def replace_workers(self):
         for index, worker in enumerate(self.worker_children):
             if not worker.is_alive():
                 logger.info(

--- a/pyqs/worker.py
+++ b/pyqs/worker.py
@@ -314,18 +314,6 @@ class SimpleProcessWorker(BaseWorker):
         start = time.time()
 
         for message in messages:
-            end = time.time()
-            if int(end - start) >= self.visibility_timeout:
-                # Don't add any more messages since they have
-                # re-appeared in the sqs queue Instead just reset and get
-                # fresh messages from the sqs queue
-                msg = (
-                    "Clearing Local messages since we exceeded "
-                    "their visibility_timeout"
-                )
-                logger.warning(msg)
-                break
-
             packed_message = {
                 "queue": self.queue_url,
                 "message": message,
@@ -366,18 +354,6 @@ class SimpleProcessWorker(BaseWorker):
         # Modify the contexts separately so the original
         # context isn't modified by later processing
         post_process_context = copy.copy(pre_process_context)
-
-        current_time = time.time()
-        if int(current_time - fetch_time) >= timeout:
-            logger.warning(
-                "Discarding task {} with args: {} and kwargs: {} due to "
-                "exceeding visibility timeout".format(  # noqa
-                    full_task_path,
-                    repr(args),
-                    repr(kwargs),
-                )
-            )
-            self.messages_processed += 1
 
         start_time = time.time()
 

--- a/tests/test_manager_worker.py
+++ b/tests/test_manager_worker.py
@@ -111,14 +111,14 @@ def test_real_main_method(ArgumentParser, _main):
     ArgumentParser.return_value.parse_args.return_value = Mock(
         concurrency=3, queues=["email1"], interval=1, batchsize=10,
         logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None,
+        access_key_id=None, secret_access_key=None, simple_worker=False,
     )
     main()
 
     _main.assert_called_once_with(
         queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=10,
         logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None,
+        access_key_id=None, secret_access_key=None, simple_worker=False,
     )
 
 

--- a/tests/test_manager_worker.py
+++ b/tests/test_manager_worker.py
@@ -439,12 +439,12 @@ def test_master_shuts_down_busy_process_workers():
     try:
         # Try Python 2 Style
         thread = ThreadWithReturnValue2(
-            target=sleep_and_kill, args=(manager.worker_children[0].pid,))
+            target=sleep_and_kill, args=(manager.reader_children[0].pid,))
         thread.daemon = True
     except TypeError:
         # Use Python 3 Style
         thread = ThreadWithReturnValue3(
-            target=sleep_and_kill, args=(manager.worker_children[0].pid,),
+            target=sleep_and_kill, args=(manager.reader_children[0].pid,),
             daemon=True,
         )
 
@@ -453,10 +453,10 @@ def test_master_shuts_down_busy_process_workers():
     # Stop the Master Process
     manager.stop()
 
-    # Check if we had to kill the Process Worker or it exited gracefully
+    # Check if we had to kill the Reader Worker or it exited gracefully
     return_value = thread.join()
     if not return_value:
-        raise Exception("Process Worker failed to quit!")
+        raise Exception("Reader Worker failed to quit!")
 
 
 @mock_sqs

--- a/tests/test_manager_worker.py
+++ b/tests/test_manager_worker.py
@@ -418,12 +418,12 @@ def test_master_shuts_down_busy_process_workers():
     try:
         # Try Python 2 Style
         thread = ThreadWithReturnValue2(
-            target=sleep_and_kill, args=(manager.reader_children[0].pid,))
+            target=sleep_and_kill, args=(manager.worker_children[0].pid,))
         thread.daemon = True
     except TypeError:
         # Use Python 3 Style
         thread = ThreadWithReturnValue3(
-            target=sleep_and_kill, args=(manager.reader_children[0].pid,),
+            target=sleep_and_kill, args=(manager.worker_children[0].pid,),
             daemon=True,
         )
 

--- a/tests/test_manager_worker.py
+++ b/tests/test_manager_worker.py
@@ -109,7 +109,28 @@ def test_real_main_method(ArgumentParser, _main):
     Test parsing of arguments from main method
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3, queues=["email1"], interval=1, batchsize=10,
+        concurrency=3, queues=["email1"], interval=1, batchsize=5,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=False,
+    )
+    main()
+
+    _main.assert_called_once_with(
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=5,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=False,
+    )
+
+
+@patch("pyqs.main._main")
+@patch("pyqs.main.ArgumentParser")
+@mock_sqs
+def test_real_main_method_default_batchsize(ArgumentParser, _main):
+    """
+    Test parsing of arguments from main method batch default
+    """
+    ArgumentParser.return_value.parse_args.return_value = Mock(
+        concurrency=3, queues=["email1"], interval=1, batchsize=None,
         logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
         access_key_id=None, secret_access_key=None, simple_worker=False,
     )
@@ -432,10 +453,10 @@ def test_master_shuts_down_busy_process_workers():
     # Stop the Master Process
     manager.stop()
 
-    # Check if we had to kill the Reader Worker or it exited gracefully
+    # Check if we had to kill the Process Worker or it exited gracefully
     return_value = thread.join()
     if not return_value:
-        raise Exception("Reader Worker failed to quit!")
+        raise Exception("Process Worker failed to quit!")
 
 
 @mock_sqs

--- a/tests/test_simple_manager_worker.py
+++ b/tests/test_simple_manager_worker.py
@@ -1,0 +1,351 @@
+import json
+import logging
+import os
+import signal
+import time
+
+import boto3
+from mock import patch, Mock, MagicMock
+from moto import mock_sqs
+
+from pyqs.main import main, _main
+from pyqs.worker import SimpleManagerWorker
+from tests.utils import (
+    MockLoggingHandler, ThreadWithReturnValue2, ThreadWithReturnValue3,
+)
+
+
+@mock_sqs
+def test_simple_manager_worker_create_proper_children_workers():
+    """
+    Test simple managing process creates multiple child workers
+    """
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="email")
+
+    manager = SimpleManagerWorker(
+        queue_prefixes=['email'], worker_concurrency=3, interval=2,
+        batchsize=10,
+    )
+
+    len(manager.worker_children).should.equal(3)
+
+
+@mock_sqs
+def test_simple_manager_worker_with_queue_prefix():
+    """
+    Test simple managing process can find queues by prefix
+    """
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="email.foobar")
+    conn.create_queue(QueueName="email.baz")
+
+    manager = SimpleManagerWorker(
+        queue_prefixes=['email.*'], worker_concurrency=1, interval=1,
+        batchsize=10,
+    )
+
+    len(manager.worker_children).should.equal(2)
+    children = manager.worker_children
+    # Pull all the read children and sort by name to make testing easier
+    sorted_children = sorted(children, key=lambda child: child.queue_url)
+
+    sorted_children[0].queue_url.should.equal(
+        "https://queue.amazonaws.com/123456789012/email.baz")
+    sorted_children[1].queue_url.should.equal(
+        "https://queue.amazonaws.com/123456789012/email.foobar")
+
+
+@mock_sqs
+def test_simple_manager_start_and_stop():
+    """
+    Test simple managing process can start and stop child processes
+    """
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="email")
+
+    manager = SimpleManagerWorker(
+        queue_prefixes=['email'], worker_concurrency=2, interval=1,
+        batchsize=10,
+    )
+
+    len(manager.worker_children).should.equal(2)
+
+    manager.worker_children[0].is_alive().should.equal(False)
+    manager.worker_children[1].is_alive().should.equal(False)
+
+    manager.start()
+
+    manager.worker_children[0].is_alive().should.equal(True)
+    manager.worker_children[1].is_alive().should.equal(True)
+
+    manager.stop()
+
+    manager.worker_children[0].is_alive().should.equal(False)
+    manager.worker_children[1].is_alive().should.equal(False)
+
+
+@patch("pyqs.main.SimpleManagerWorker")
+@mock_sqs
+def test_main_method(SimpleManagerWorker):
+    """
+    Test creation of simple manager process from _main method
+    """
+    _main(["email1", "email2"], concurrency=2, simple_worker=True)
+
+    SimpleManagerWorker.assert_called_once_with(
+        ['email1', 'email2'], 2, 1, 10,
+        region=None, secret_access_key=None, access_key_id=None,
+    )
+    SimpleManagerWorker.return_value.start.assert_called_once_with()
+
+
+@patch("pyqs.main._main")
+@patch("pyqs.main.ArgumentParser")
+@mock_sqs
+def test_real_main_method(ArgumentParser, _main):
+    """
+    Test parsing of arguments from main method
+    """
+    ArgumentParser.return_value.parse_args.return_value = Mock(
+        concurrency=3, queues=["email1"], interval=1, batchsize=10,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=True,
+    )
+    main()
+
+    _main.assert_called_once_with(
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=10,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=True,
+    )
+
+
+@mock_sqs
+def test_master_spawns_worker_processes():
+    """
+    Test simple managing process creates child workers
+    """
+
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="tester")
+
+    # Setup Manager
+    manager = SimpleManagerWorker(["tester"], 1, 1, 10)
+    manager.start()
+
+    # Check Workers
+    len(manager.worker_children).should.equal(1)
+
+    manager.worker_children[0].is_alive().should.be.true
+
+    # Cleanup
+    manager.stop()
+
+
+@mock_sqs
+def test_master_counts_processes():
+    """
+    Test simple managing process counts child processes
+    """
+
+    # Setup Logging
+    logger = logging.getLogger("pyqs")
+    del logger.handlers[:]
+    logger.handlers.append(MockLoggingHandler())
+
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="tester")
+
+    # Setup Manager
+    manager = SimpleManagerWorker(["tester"], 2, 1, 10)
+    manager.start()
+
+    # Check Workers
+    manager.process_counts()
+
+    # Cleanup
+    manager.stop()
+
+    # Check messages
+    msg2 = "Worker Processes: 2"
+    logger.handlers[0].messages['debug'][-1].lower().should.contain(
+        msg2.lower())
+
+
+@mock_sqs
+def test_master_replaces_worker_processes():
+    """
+    Test simple managing process replaces worker processes
+    """
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="tester")
+
+    # Setup Manager
+    manager = SimpleManagerWorker(
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        batchsize=10,
+    )
+    manager.start()
+
+    # Get Worker PID
+    pid = manager.worker_children[0].pid
+
+    # Kill Worker and wait to replace
+    manager.worker_children[0].shutdown()
+    time.sleep(0.1)
+    manager.replace_workers()
+
+    # Check Replacement
+    manager.worker_children[0].pid.shouldnt.equal(pid)
+
+    # Cleanup
+    manager.stop()
+
+
+@mock_sqs
+@patch("pyqs.worker.sys")
+def test_master_handles_signals(sys):
+    """
+    Test simple managing process handles OS signals
+    """
+
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="tester")
+
+    # Mock out sys.exit
+    sys.exit = Mock()
+
+    # Have our inner method send our signal
+    def process_counts():
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    # Setup Manager
+    manager = SimpleManagerWorker(
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        batchsize=10,
+    )
+    manager.process_counts = process_counts
+    manager._graceful_shutdown = MagicMock()
+
+    # When we start and trigger a signal
+    manager.start()
+    manager.sleep()
+
+    # Then we exit
+    sys.exit.assert_called_once_with(0)
+
+
+@mock_sqs
+def test_master_shuts_down_busy_process_workers():
+    """
+    Test simple managing process properly cleans up busy Process Workers
+    """
+    # For debugging test
+    import sys
+    logger = logging.getLogger("pyqs")
+    logger.setLevel(logging.DEBUG)
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    logger.addHandler(stdout_handler)
+
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+
+    # Add Slow tasks
+    message = json.dumps({
+        'task': 'tests.tasks.sleeper',
+        'args': [],
+        'kwargs': {
+            'message': 5,
+        },
+    })
+
+    # Fill the queue (we need a lot of messages to trigger the bug)
+    for _ in range(20):
+        conn.send_message(QueueUrl=queue_url, MessageBody=message)
+
+    # Create function to watch and kill stuck processes
+    def sleep_and_kill(pid):
+        import os
+        import signal
+        import time
+        # This sleep time is long enoug for 100 messages in queue
+        time.sleep(5)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            # Return that we didn't need to kill the process
+            return True
+        else:
+            # Return that we needed to kill the process
+            return False
+
+    # Setup Manager
+    manager = SimpleManagerWorker(
+        queue_prefixes=["tester"], worker_concurrency=1, interval=0.0,
+        batchsize=1,
+    )
+    manager.start()
+
+    # Give our processes a moment to start
+    time.sleep(1)
+
+    # Setup Threading watcher
+    try:
+        # Try Python 2 Style
+        thread = ThreadWithReturnValue2(
+            target=sleep_and_kill, args=(manager.worker_children[0].pid,))
+        thread.daemon = True
+    except TypeError:
+        # Use Python 3 Style
+        thread = ThreadWithReturnValue3(
+            target=sleep_and_kill, args=(manager.worker_children[0].pid,),
+            daemon=True,
+        )
+
+    thread.start()
+
+    # Stop the Master Process
+    manager.stop()
+
+    # Check if we had to kill the Reader Worker or it exited gracefully
+    return_value = thread.join()
+    if not return_value:
+        raise Exception("Reader Worker failed to quit!")
+
+
+@mock_sqs
+def test_manager_picks_up_new_queues():
+    """
+    Test that the simple manager will recognize new SQS queues have been added
+    """
+
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+
+    # Setup Manager
+    manager = SimpleManagerWorker(
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        batchsize=10,
+    )
+    manager.start()
+
+    # No queues found
+    len(manager.worker_children).should.equal(0)
+
+    # Create the queue
+    conn.create_queue(QueueName="tester")
+    manager.check_for_new_queues()
+
+    # The manager should have seen the new queue was created and add a reader
+    len(manager.worker_children).should.equal(1)
+    manager.worker_children[0].queue_url.should.equal(
+        "https://queue.amazonaws.com/123456789012/tester")
+
+    # Cleanup
+    manager.stop()

--- a/tests/test_simple_manager_worker.py
+++ b/tests/test_simple_manager_worker.py
@@ -108,14 +108,35 @@ def test_real_main_method(ArgumentParser, _main):
     Test parsing of arguments from main method
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3, queues=["email1"], interval=1, batchsize=10,
+        concurrency=3, queues=["email1"], interval=1, batchsize=5,
         logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
         access_key_id=None, secret_access_key=None, simple_worker=True,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=10,
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=5,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=True,
+    )
+
+
+@patch("pyqs.main._main")
+@patch("pyqs.main.ArgumentParser")
+@mock_sqs
+def test_real_main_method_default_batchsize(ArgumentParser, _main):
+    """
+    Test parsing of arguments from main method batch default
+    """
+    ArgumentParser.return_value.parse_args.return_value = Mock(
+        concurrency=3, queues=["email1"], interval=1, batchsize=None,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=True,
+    )
+    main()
+
+    _main.assert_called_once_with(
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=1,
         logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
         access_key_id=None, secret_access_key=None, simple_worker=True,
     )
@@ -313,10 +334,10 @@ def test_master_shuts_down_busy_process_workers():
     # Stop the Master Process
     manager.stop()
 
-    # Check if we had to kill the Reader Worker or it exited gracefully
+    # Check if we had to kill the Process Worker or it exited gracefully
     return_value = thread.join()
     if not return_value:
-        raise Exception("Reader Worker failed to quit!")
+        raise Exception("Process Worker failed to quit!")
 
 
 @mock_sqs

--- a/tests/test_simple_worker.py
+++ b/tests/test_simple_worker.py
@@ -1,0 +1,649 @@
+import json
+import logging
+import time
+
+import boto3
+from botocore.exceptions import ClientError
+from moto import mock_sqs
+from mock import patch, Mock
+from pyqs.worker import (
+    SimpleManagerWorker, BaseProcessWorker, SimpleProcessWorker,
+    MESSAGE_DOWNLOAD_BATCH_SIZE
+)
+from pyqs.utils import decode_message
+from pyqs.events import register_event
+from tests.utils import MockLoggingHandler, clear_events_registry
+
+BATCHSIZE = 10
+INTERVAL = 0.1
+
+
+def _create_packed_message(task_name):
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+
+    # Build the SQS message
+    message = {
+        'Body': json.dumps({
+            'task': task_name,
+            'args': [],
+            'kwargs': {
+                'message': 'Test message',
+            },
+        }),
+        "ReceiptHandle": "receipt-1234",
+    }
+
+    packed_message = {
+        "queue": queue_url,
+        "message": message,
+        "start_time": time.time(),
+        "timeout": 30,
+    }
+
+    return queue_url, packed_message
+
+
+def _add_messages_to_sqs(task_name, num):
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+
+    # Build the SQS message
+    message = json.dumps({
+        'task': task_name,
+        'args': [],
+        'kwargs': {
+            'message': 'Test message',
+        },
+    })
+
+    for i in range(num):
+        conn.send_message(QueueUrl=queue_url, MessageBody=message)
+
+    return queue_url
+
+
+@mock_sqs
+def test_worker_reads_messages_from_sqs():
+    """
+    Test simple worker reads from sqs queue
+    """
+    queue_url = _add_messages_to_sqs('tests.tasks.index_incrementer', 1)
+
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    messages = worker.read_message()
+
+    found_message_body = decode_message(messages[0])
+    found_message_body.should.equal({
+        'task': 'tests.tasks.index_incrementer',
+        'args': [],
+        'kwargs': {
+            'message': 'Test message',
+        },
+    })
+
+
+@mock_sqs
+def test_worker_throws_error_when_exceeding_max_number_of_messages_for_read():
+    """
+    Test simple worker reads from sqs queue and throws error when batchsize
+    greater than 10
+    """
+    queue_url = _add_messages_to_sqs('tests.tasks.index_incrementer', 1)
+
+    worker = SimpleProcessWorker(queue_url, INTERVAL, 20, parent_id=1)
+
+    error_msg = "Value 20 for parameter MaxNumberOfMessages is invalid"
+
+    try:
+        worker.read_message()
+    except ClientError as exc:
+        str(exc).should.contain(error_msg)
+
+
+@mock_sqs
+def test_worker_reads_max_messages_from_sqs():
+    """
+    Test simple worker reads at maximum 10 message from sqs queue
+    """
+    _add_messages_to_sqs('tests.tasks.index_incrementer', 12)
+
+    manager = SimpleManagerWorker(
+        queue_prefixes=['tester'], worker_concurrency=1, interval=INTERVAL,
+        batchsize=20,
+    )
+    worker = manager.worker_children[0]
+    messages = worker.read_message()
+
+    messages.should.have.length_of(BATCHSIZE)
+
+
+@mock_sqs
+def test_worker_fills_internal_queue_from_celery_task():
+    """
+    Test simple worker reads from sqs queue with celery tasks
+    """
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+
+    message = (
+        '{"body": "KGRwMApTJ3Rhc2snCnAxClMndGVzdHMudGFza3MuaW5kZXhfa'
+        'W5jcmVtZW50ZXInCnAyCnNTJ2Fy\\nZ3MnCnAzCihscDQKc1Mna3dhcmdzJw'
+        'pwNQooZHA2ClMnbWVzc2FnZScKcDcKUydUZXN0IG1lc3Nh\\nZ2UyJwpwOAp'
+        'zcy4=\\n", "some stuff": "asdfasf"}'
+    )
+    conn.send_message(QueueUrl=queue_url, MessageBody=message)
+
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    messages = worker.read_message()
+
+    found_message_body = decode_message(messages[0])
+    found_message_body.should.equal({
+        'task': 'tests.tasks.index_incrementer',
+        'args': [],
+        'kwargs': {
+            'message': 'Test message2',
+        },
+    })
+
+
+@mock_sqs
+def test_worker_processes_tasks_and_logs_correctly():
+    """
+    Test simple worker processes logs INFO correctly
+    """
+    # Setup logging
+    logger = logging.getLogger("pyqs")
+    del logger.handlers[:]
+    logger.handlers.append(MockLoggingHandler())
+
+    queue_url, packed_message = _create_packed_message(
+        'tests.tasks.index_incrementer'
+    )
+
+    # Process message
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message(packed_message)
+
+    # Check output
+    kwargs = json.loads(packed_message["message"]['Body'])['kwargs']
+    expected_result = (
+        u"Processed task tests.tasks.index_incrementer in 0.0000 seconds "
+        "with args: [] and kwargs: {}".format(kwargs)
+    )
+    logger.handlers[0].messages['info'].should.equal([expected_result])
+
+
+@mock_sqs
+def test_worker_processes_tasks_and_logs_warning_correctly():
+    """
+    Test simple worker processes logs WARNING correctly
+    """
+    # Setup logging
+    logger = logging.getLogger("pyqs")
+    del logger.handlers[:]
+    logger.handlers.append(MockLoggingHandler())
+
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+
+    # Build the SQS Message
+    message = {
+        'Body': json.dumps({
+            'task': 'tests.tasks.index_incrementer',
+            'args': [],
+            'kwargs': {
+                'message': 23,
+            },
+        }),
+        "ReceiptHandle": "receipt-1234",
+    }
+
+    packed_message = {
+        "queue": queue_url,
+        "message": message,
+        "start_time": time.time(),
+        "timeout": 30,
+    }
+
+    # Process message
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message(packed_message)
+
+    # Check output
+    kwargs = json.loads(message['Body'])['kwargs']
+    msg1 = (
+        "Task tests.tasks.index_incrementer raised error in 0.0000 seconds: "
+        "with args: [] and kwargs: {}: "
+        "Traceback (most recent call last)".format(kwargs)
+    )  # noqa
+    logger.handlers[0].messages['error'][0].lower().should.contain(
+        msg1.lower())
+    msg2 = (
+        'ValueError: Need to be given basestring, '
+        'was given 23'
+    )  # noqa
+    logger.handlers[0].messages['error'][0].lower().should.contain(
+        msg2.lower())
+
+
+@patch("pyqs.worker.os")
+def test_parent_process_death(os):
+    """
+    Test simple worker processes recognize parent process death
+    """
+    os.getppid.return_value = 123
+
+    worker = BaseProcessWorker(parent_id=1)
+    worker.parent_is_alive().should.be.false
+
+
+@patch("pyqs.worker.os")
+def test_parent_process_alive(os):
+    """
+    Test simple worker processes recognize when parent process is alive
+    """
+    os.getppid.return_value = 1234
+
+    worker = BaseProcessWorker(parent_id=1234)
+    worker.parent_is_alive().should.be.true
+
+
+@mock_sqs
+@patch("pyqs.worker.os")
+def test_read_message_with_parent_process_alive_and_should_not_exit(os):
+    """
+    Test simple worker processes do not exit when parent is alive and shutdown
+    is not set when reading message
+    """
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+
+    # Setup PPID
+    os.getppid.return_value = 1
+
+    # Setup dummy read_message
+    def read_message():
+        raise Exception("Called")
+
+    # When I have a parent process, and shutdown is not set
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.read_message = read_message
+
+    # Then read_message() is reached
+    worker.run.when.called_with().should.throw(Exception, "Called")
+
+
+@mock_sqs
+@patch("pyqs.worker.os")
+def test_read_message_with_parent_process_alive_and_should_exit(os):
+    """
+    Test simple worker processes exit when parent is alive and shutdown is set
+    when reading message
+    """
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+
+    # Setup PPID
+    os.getppid.return_value = 1234
+
+    # When I have a parent process, and shutdown is set
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.read_message = Mock()
+    worker.shutdown()
+
+    # Then I return from run()
+    worker.run().should.be.none
+
+
+@mock_sqs
+@patch("pyqs.worker.os")
+def test_read_message_with_parent_process_dead_and_should_not_exit(os):
+    """
+    Test simple worker processes exit when parent is dead and shutdown is not
+    set when reading messages
+    """
+    # Setup SQS Queue
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+
+    # Setup PPID
+    os.getppid.return_value = 123
+
+    # When I have no parent process, and shutdown is not set
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.read_message = Mock()
+
+    # Then I return from run()
+    worker.run().should.be.none
+
+
+@mock_sqs
+@patch("pyqs.worker.os")
+def test_process_message_with_parent_process_alive_and_should_not_exit(os):
+    """
+    Test simple worker processes do not exit when parent is alive and shutdown
+    is not set when processing message
+    """
+    queue_url = _add_messages_to_sqs('tests.tasks.index_incrementer', 1)
+
+    # Setup PPID
+    os.getppid.return_value = 1
+
+    # Setup dummy read_message
+    def process_message(packed_message):
+        raise Exception("Called")
+
+    # When I have a parent process, and shutdown is not set
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message = process_message
+
+    # Then process_message() is reached
+    worker.run.when.called_with().should.throw(Exception, "Called")
+
+
+@mock_sqs
+@patch("pyqs.worker.os")
+def test_process_message_with_parent_process_dead_and_should_not_exit(os):
+    """
+    Test simple worker processes exit when parent is dead and shutdown is not
+    set when processing message
+    """
+
+    queue_url = _add_messages_to_sqs('tests.tasks.index_incrementer', 1)
+
+    # Setup PPID
+    os.getppid.return_value = 123
+
+    # When I have a parent process, and shutdown is not set
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message = Mock()
+
+    # Then process_message() is reached
+    worker.run().should.be.none
+
+
+@mock_sqs
+@patch("pyqs.worker.os")
+def test_process_message_with_parent_process_alive_and_should_exit(os):
+    """
+    Test simple worker processes exit when parent is alive and shutdown is set
+    set when processing message
+    """
+
+    queue_url = _add_messages_to_sqs('tests.tasks.index_incrementer', 1)
+
+    # Setup PPID
+    os.getppid.return_value = 1
+
+    # When I have a parent process, and shutdown is not set
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message = Mock()
+    worker.shutdown()
+
+    # Then process_message() is reached
+    worker.run().should.be.none
+
+
+@mock_sqs
+@patch("pyqs.worker.os")
+def test_worker_processes_shuts_down_after_processing_its_max_number_of_msgs(
+        os):
+    """
+    Test simple worker processes shutdown after processing maximum number
+    of messages
+    """
+    os.getppid.return_value = 1
+
+    queue_url = _add_messages_to_sqs('tests.tasks.index_incrementer', 2)
+
+    # When I Process messages
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker._messages_to_process_before_shutdown = 2
+
+    # Then I return from run()
+    worker.run().should.be.none
+
+
+@mock_sqs
+def test_worker_negative_batch_size():
+    """
+    Test simple workers with negative batch sizes
+    """
+    BATCHSIZE = -1
+    CONCURRENCY = 1
+    QUEUE_PREFIX = "tester"
+    INTERVAL = 0.0
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="tester")['QueueUrl']
+
+    worker = SimpleManagerWorker(
+        QUEUE_PREFIX,
+        CONCURRENCY,
+        INTERVAL,
+        BATCHSIZE
+    )
+    worker.batchsize.should.equal(1)
+
+
+@mock_sqs
+def test_worker_to_large_batch_size():
+    """
+    Test simple workers with too large of a batch size
+    """
+    BATCHSIZE = 10000
+    CONCURRENCY = 1
+    QUEUE_PREFIX = "tester"
+    INTERVAL = 0.0
+    conn = boto3.client('sqs', region_name='us-east-1')
+    conn.create_queue(QueueName="tester")['QueueUrl']
+
+    worker = SimpleManagerWorker(
+        QUEUE_PREFIX,
+        CONCURRENCY,
+        INTERVAL,
+        BATCHSIZE
+    )
+    worker.batchsize.should.equal(MESSAGE_DOWNLOAD_BATCH_SIZE)
+
+
+@clear_events_registry
+@mock_sqs
+def test_worker_processes_tasks_with_pre_process_callback():
+    """
+    Test simple worker runs registered callbacks when processing a message
+    """
+
+    queue_url, packed_message = _create_packed_message(
+        'tests.tasks.index_incrementer'
+    )
+
+    # Declare this so it can be checked as a side effect
+    # to pre_process_with_side_effect
+    contexts = []
+
+    def pre_process_with_side_effect(context):
+        contexts.append(context)
+
+    # When we have a registered pre_process callback
+    register_event("pre_process", pre_process_with_side_effect)
+
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message(packed_message)
+
+    pre_process_context = contexts[0]
+
+    # We should run the callback with the task context
+    pre_process_context['task_name'].should.equal('index_incrementer')
+    pre_process_context['args'].should.equal([])
+    pre_process_context['kwargs'].should.equal({'message': 'Test message'})
+    pre_process_context['full_task_path'].should.equal(
+        'tests.tasks.index_incrementer'
+    )
+    pre_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
+    pre_process_context['timeout'].should.equal(30)
+
+    assert 'fetch_time' in pre_process_context
+    assert 'receipt_handle' in pre_process_context
+    assert 'status' not in pre_process_context
+
+
+@clear_events_registry
+@mock_sqs
+def test_worker_processes_tasks_with_post_process_callback_success():
+    """
+    Test simple worker runs registered callbacks when
+    processing a message and it succeeds
+    """
+
+    queue_url, packed_message = _create_packed_message(
+        'tests.tasks.index_incrementer'
+    )
+
+    # Declare this so it can be checked as a side effect
+    # to post_process_with_side_effect
+    contexts = []
+
+    def post_process_with_side_effect(context):
+        contexts.append(context)
+
+    # When we have a registered post_process callback
+    register_event("post_process", post_process_with_side_effect)
+
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message(packed_message)
+
+    post_process_context = contexts[0]
+
+    # We should run the callback with the task context
+    post_process_context['task_name'].should.equal('index_incrementer')
+    post_process_context['args'].should.equal([])
+    post_process_context['kwargs'].should.equal({'message': 'Test message'})
+    post_process_context['full_task_path'].should.equal(
+        'tests.tasks.index_incrementer'
+    )
+    post_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
+    post_process_context['timeout'].should.equal(30)
+    post_process_context['status'].should.equal('success')
+
+    assert 'fetch_time' in post_process_context
+    assert 'receipt_handle' in post_process_context
+    assert 'exception' not in post_process_context
+
+
+@clear_events_registry
+@mock_sqs
+def test_worker_processes_tasks_with_post_process_callback_exception():
+    """
+    Test simple worker runs registered callbacks when processing
+    a message and it fails
+    """
+
+    queue_url, packed_message = _create_packed_message(
+        'tests.tasks.exception_task'
+    )
+
+    # Declare this so it can be checked as a side effect
+    # to post_process_with_side_effect
+    contexts = []
+
+    def post_process_with_side_effect(context):
+        contexts.append(context)
+
+    # When we have a registered post_process callback
+    register_event("post_process", post_process_with_side_effect)
+
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message(packed_message)
+
+    post_process_context = contexts[0]
+
+    # We should run the callback with the task context
+    post_process_context['task_name'].should.equal('exception_task')
+    post_process_context['args'].should.equal([])
+    post_process_context['kwargs'].should.equal({'message': 'Test message'})
+    post_process_context['full_task_path'].should.equal(
+        'tests.tasks.exception_task'
+    )
+    post_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
+    post_process_context['timeout'].should.equal(30)
+    post_process_context['status'].should.equal('exception')
+
+    assert 'fetch_time' in post_process_context
+    assert 'receipt_handle' in post_process_context
+    assert 'exception' in post_process_context
+
+
+@clear_events_registry
+@mock_sqs
+def test_worker_processes_tasks_with_pre_and_post_process():
+    """
+    Test worker runs registered callbacks when processing a message
+    """
+
+    queue_url, packed_message = _create_packed_message(
+        'tests.tasks.index_incrementer'
+    )
+
+    # Declare these so they can be checked as a side effect to the callbacks
+    contexts = []
+
+    def pre_process_with_side_effect(context):
+        contexts.append(context)
+
+    def post_process_with_side_effect(context):
+        contexts.append(context)
+
+    # When we have a registered pre_process and post_process callback
+    register_event("pre_process", pre_process_with_side_effect)
+    register_event("post_process", post_process_with_side_effect)
+
+    worker = SimpleProcessWorker(queue_url, INTERVAL, BATCHSIZE, parent_id=1)
+    worker.process_message(packed_message)
+
+    pre_process_context = contexts[0]
+
+    # We should run the callbacks with the right task contexts
+    pre_process_context['task_name'].should.equal('index_incrementer')
+    pre_process_context['args'].should.equal([])
+    pre_process_context['kwargs'].should.equal({'message': 'Test message'})
+    pre_process_context['full_task_path'].should.equal(
+        'tests.tasks.index_incrementer'
+    )
+    pre_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
+    pre_process_context['timeout'].should.equal(30)
+
+    assert 'fetch_time' in pre_process_context
+    assert 'receipt_handle' in pre_process_context
+    assert 'status' not in pre_process_context
+
+    post_process_context = contexts[1]
+
+    post_process_context['task_name'].should.equal('index_incrementer')
+    post_process_context['args'].should.equal([])
+    post_process_context['kwargs'].should.equal({'message': 'Test message'})
+    post_process_context['full_task_path'].should.equal(
+        'tests.tasks.index_incrementer'
+    )
+    post_process_context['queue_url'].should.equal(
+        'https://queue.amazonaws.com/123456789012/tester'
+    )
+    post_process_context['timeout'].should.equal(30)
+    post_process_context['status'].should.equal('success')
+
+    assert 'fetch_time' in post_process_context
+    assert 'receipt_handle' in post_process_context
+    assert 'exception' not in post_process_context


### PR DESCRIPTION
## About
- This PR creates a `SimpleProcessWorker` and `SimpleManagerWorker`
- Removes the internal queue
- Combines the functionality of the `ReadWorker` and `ProcessWorker` into the `SimpleProcessWorker`
- Adds a `simple-worker` flag to use the new `SimpleManagerWorker`
- Keeps support for multiple queues, `concurrency`, `batchsize`, and `interval`; removes `prefetch-multiplier` support when using `SimpleManagerWorker`
- Conducted throughput testing to make sure that `SimpleProcessWorker` does not lose any throughput when compared to `ProcessWorker`

## To Do
- [x] See if it makes sense to make things more DRY between `ReadWorker`, `ProcessWorker` and `SimpleProcessWorker` by subclassing from a common parent
- [x] See if it makes sense to make things more DRY between `SimpleManagerWorker` and `MangerWorker` by subclassing from a common parent
- [x] Add tests for new classes
- [x] Update README

## Decisions
- **Decision 1**: For `SimpleProcessWorker`, do we want to keep track of number of `messages_processed` due to memory implications, is this relevant still?
  - **Decision 1a**: If we keep this, do we count a message grabbed and discarded due to visibility timeout as a going against the count, i.e  `messages_processed`?
- **Decision 2**: Should `read_message` in `SimpleProcessWorker` break or not do the visibility timeout check here at all since we are doing it in `process_message`?
- **Decision 3**: Should we immediately make messages visible that have failed, but have a long visibility timeout?
- **Decision 4**: Do we support `batchsize` in `SimpleProcessWorker`?
- **Decision 5**: Support multiple sqs queues for `SimpleManagerWorker`?
- **Decision 6**: Support `concurrency` for `SimpleManagerWorker`?