### PR TITLE
As a starting point fix tests that were broken by PR #81 for endpoint_url

### DIFF
--- a/tests/test_manager_worker.py
+++ b/tests/test_manager_worker.py
@@ -11,7 +11,9 @@ from moto import mock_sqs
 from pyqs.main import main, _main
 from pyqs.worker import ManagerWorker
 from tests.utils import (
-    MockLoggingHandler, ThreadWithReturnValue2, ThreadWithReturnValue3,
+    MockLoggingHandler,
+    ThreadWithReturnValue2,
+    ThreadWithReturnValue3,
 )
 
 
@@ -20,11 +22,13 @@ def test_manager_worker_create_proper_children_workers():
     """
     Test managing process creates multiple child workers
     """
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="email")
 
     manager = ManagerWorker(
-        queue_prefixes=['email'], worker_concurrency=3, interval=2,
+        queue_prefixes=["email"],
+        worker_concurrency=3,
+        interval=2,
         batchsize=10,
     )
 
@@ -37,12 +41,14 @@ def test_manager_worker_with_queue_prefix():
     """
     Test managing process can find queues by prefix
     """
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="email.foobar")
     conn.create_queue(QueueName="email.baz")
 
     manager = ManagerWorker(
-        queue_prefixes=['email.*'], worker_concurrency=1, interval=1,
+        queue_prefixes=["email.*"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
 
@@ -52,9 +58,11 @@ def test_manager_worker_with_queue_prefix():
     sorted_children = sorted(children, key=lambda child: child.queue_url)
 
     sorted_children[0].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/email.baz")
+        "https://queue.amazonaws.com/123456789012/email.baz"
+    )
     sorted_children[1].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/email.foobar")
+        "https://queue.amazonaws.com/123456789012/email.foobar"
+    )
 
 
 @mock_sqs
@@ -62,11 +70,13 @@ def test_manager_start_and_stop():
     """
     Test managing process can start and stop child processes
     """
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="email")
 
     manager = ManagerWorker(
-        queue_prefixes=['email'], worker_concurrency=2, interval=1,
+        queue_prefixes=["email"],
+        worker_concurrency=2,
+        interval=1,
         batchsize=10,
     )
 
@@ -95,8 +105,15 @@ def test_main_method(ManagerWorker):
     _main(["email1", "email2"], concurrency=2)
 
     ManagerWorker.assert_called_once_with(
-        ['email1', 'email2'], 2, 1, 10, prefetch_multiplier=2,
-        region=None, secret_access_key=None, access_key_id=None,
+        ["email1", "email2"],
+        2,
+        1,
+        10,
+        prefetch_multiplier=2,
+        region=None,
+        secret_access_key=None,
+        access_key_id=None,
+        endpoint_url=None,
     )
     ManagerWorker.return_value.start.assert_called_once_with()
 
@@ -109,16 +126,32 @@ def test_real_main_method(ArgumentParser, _main):
     Test parsing of arguments from main method
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3, queues=["email1"], interval=1, batchsize=5,
-        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None, simple_worker=False,
+        concurrency=3,
+        queues=["email1"],
+        interval=1,
+        batchsize=5,
+        logging_level="WARN",
+        region="us-east-1",
+        prefetch_multiplier=2,
+        access_key_id=None,
+        secret_access_key=None,
+        simple_worker=False,
+        endpoint_url=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=5,
-        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None, simple_worker=False,
+        queue_prefixes=["email1"],
+        concurrency=3,
+        interval=1,
+        batchsize=5,
+        logging_level="WARN",
+        region="us-east-1",
+        prefetch_multiplier=2,
+        access_key_id=None,
+        secret_access_key=None,
+        simple_worker=False,
+        endpoint_url=None,
     )
 
 
@@ -130,16 +163,32 @@ def test_real_main_method_default_batchsize(ArgumentParser, _main):
     Test parsing of arguments from main method batch default
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3, queues=["email1"], interval=1, batchsize=None,
-        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None, simple_worker=False,
+        concurrency=3,
+        queues=["email1"],
+        interval=1,
+        batchsize=None,
+        logging_level="WARN",
+        region="us-east-1",
+        prefetch_multiplier=2,
+        access_key_id=None,
+        secret_access_key=None,
+        simple_worker=False,
+        endpoint_url=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=10,
-        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None, simple_worker=False,
+        queue_prefixes=["email1"],
+        concurrency=3,
+        interval=1,
+        batchsize=10,
+        logging_level="WARN",
+        region="us-east-1",
+        prefetch_multiplier=2,
+        access_key_id=None,
+        secret_access_key=None,
+        simple_worker=False,
+        endpoint_url=None,
     )
 
 
@@ -150,7 +199,7 @@ def test_master_spawns_worker_processes():
     """
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
@@ -176,12 +225,14 @@ def test_master_replaces_reader_processes():
     """
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
     manager.start()
@@ -213,7 +264,7 @@ def test_master_counts_processes():
     logger.handlers.append(MockLoggingHandler())
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
@@ -228,11 +279,9 @@ def test_master_counts_processes():
 
     # Check messages
     msg1 = "Reader Processes: 1"
-    logger.handlers[0].messages['debug'][-2].lower().should.contain(
-        msg1.lower())
+    logger.handlers[0].messages["debug"][-2].lower().should.contain(msg1.lower())
     msg2 = "Worker Processes: 2"
-    logger.handlers[0].messages['debug'][-1].lower().should.contain(
-        msg2.lower())
+    logger.handlers[0].messages["debug"][-1].lower().should.contain(msg2.lower())
 
 
 @mock_sqs
@@ -241,12 +290,14 @@ def test_master_replaces_worker_processes():
     Test managing process replaces worker processes
     """
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
     manager.start()
@@ -274,7 +325,7 @@ def test_master_handles_signals(sys):
     """
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Mock out sys.exit
@@ -286,7 +337,9 @@ def test_master_handles_signals(sys):
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
     manager.process_counts = process_counts
@@ -308,23 +361,26 @@ def test_master_shuts_down_busy_read_workers():
     """
     # For debugging test
     import sys
+
     logger = logging.getLogger("pyqs")
     logger.setLevel(logging.DEBUG)
     stdout_handler = logging.StreamHandler(sys.stdout)
     logger.addHandler(stdout_handler)
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
-    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+    conn = boto3.client("sqs", region_name="us-east-1")
+    queue_url = conn.create_queue(QueueName="tester")["QueueUrl"]
 
     # Add Slow tasks
-    message = json.dumps({
-        'task': 'tests.tasks.sleeper',
-        'args': [],
-        'kwargs': {
-            'message': 5,
-        },
-    })
+    message = json.dumps(
+        {
+            "task": "tests.tasks.sleeper",
+            "args": [],
+            "kwargs": {
+                "message": 5,
+            },
+        }
+    )
 
     # Fill the queue (we need a lot of messages to trigger the bug)
     for _ in range(20):
@@ -335,6 +391,7 @@ def test_master_shuts_down_busy_read_workers():
         import os
         import signal
         import time
+
         # This sleep time is long enoug for 100 messages in queue
         time.sleep(5)
         try:
@@ -348,7 +405,9 @@ def test_master_shuts_down_busy_read_workers():
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=0, interval=0.0,
+        queue_prefixes=["tester"],
+        worker_concurrency=0,
+        interval=0.0,
         batchsize=1,
     )
     manager.start()
@@ -360,12 +419,14 @@ def test_master_shuts_down_busy_read_workers():
     try:
         # Try Python 2 Style
         thread = ThreadWithReturnValue2(
-            target=sleep_and_kill, args=(manager.reader_children[0].pid,))
+            target=sleep_and_kill, args=(manager.reader_children[0].pid,)
+        )
         thread.daemon = True
     except TypeError:
         # Use Python 3 Style
         thread = ThreadWithReturnValue3(
-            target=sleep_and_kill, args=(manager.reader_children[0].pid,),
+            target=sleep_and_kill,
+            args=(manager.reader_children[0].pid,),
             daemon=True,
         )
 
@@ -387,23 +448,26 @@ def test_master_shuts_down_busy_process_workers():
     """
     # For debugging test
     import sys
+
     logger = logging.getLogger("pyqs")
     logger.setLevel(logging.DEBUG)
     stdout_handler = logging.StreamHandler(sys.stdout)
     logger.addHandler(stdout_handler)
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
-    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+    conn = boto3.client("sqs", region_name="us-east-1")
+    queue_url = conn.create_queue(QueueName="tester")["QueueUrl"]
 
     # Add Slow tasks
-    message = json.dumps({
-        'task': 'tests.tasks.sleeper',
-        'args': [],
-        'kwargs': {
-            'message': 5,
-        },
-    })
+    message = json.dumps(
+        {
+            "task": "tests.tasks.sleeper",
+            "args": [],
+            "kwargs": {
+                "message": 5,
+            },
+        }
+    )
 
     # Fill the queue (we need a lot of messages to trigger the bug)
     for _ in range(20):
@@ -414,6 +478,7 @@ def test_master_shuts_down_busy_process_workers():
         import os
         import signal
         import time
+
         # This sleep time is long enoug for 100 messages in queue
         time.sleep(5)
         try:
@@ -427,7 +492,9 @@ def test_master_shuts_down_busy_process_workers():
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=0.0,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=0.0,
         batchsize=1,
     )
     manager.start()
@@ -439,12 +506,14 @@ def test_master_shuts_down_busy_process_workers():
     try:
         # Try Python 2 Style
         thread = ThreadWithReturnValue2(
-            target=sleep_and_kill, args=(manager.reader_children[0].pid,))
+            target=sleep_and_kill, args=(manager.reader_children[0].pid,)
+        )
         thread.daemon = True
     except TypeError:
         # Use Python 3 Style
         thread = ThreadWithReturnValue3(
-            target=sleep_and_kill, args=(manager.reader_children[0].pid,),
+            target=sleep_and_kill,
+            args=(manager.reader_children[0].pid,),
             daemon=True,
         )
 
@@ -466,11 +535,13 @@ def test_manager_picks_up_new_queues():
     """
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
     manager.start()
@@ -485,7 +556,8 @@ def test_manager_picks_up_new_queues():
     # The manager should have seen the new queue was created and add a reader
     len(manager.reader_children).should.equal(1)
     manager.reader_children[0].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/tester")
+        "https://queue.amazonaws.com/123456789012/tester"
+    )
 
     # Cleanup
     manager.stop()

--- a/tests/test_manager_worker.py
+++ b/tests/test_manager_worker.py
@@ -11,9 +11,7 @@ from moto import mock_sqs
 from pyqs.main import main, _main
 from pyqs.worker import ManagerWorker
 from tests.utils import (
-    MockLoggingHandler,
-    ThreadWithReturnValue2,
-    ThreadWithReturnValue3,
+    MockLoggingHandler, ThreadWithReturnValue2, ThreadWithReturnValue3,
 )
 
 
@@ -22,13 +20,11 @@ def test_manager_worker_create_proper_children_workers():
     """
     Test managing process creates multiple child workers
     """
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="email")
 
     manager = ManagerWorker(
-        queue_prefixes=["email"],
-        worker_concurrency=3,
-        interval=2,
+        queue_prefixes=['email'], worker_concurrency=3, interval=2,
         batchsize=10,
     )
 
@@ -41,14 +37,12 @@ def test_manager_worker_with_queue_prefix():
     """
     Test managing process can find queues by prefix
     """
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="email.foobar")
     conn.create_queue(QueueName="email.baz")
 
     manager = ManagerWorker(
-        queue_prefixes=["email.*"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=['email.*'], worker_concurrency=1, interval=1,
         batchsize=10,
     )
 
@@ -58,11 +52,9 @@ def test_manager_worker_with_queue_prefix():
     sorted_children = sorted(children, key=lambda child: child.queue_url)
 
     sorted_children[0].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/email.baz"
-    )
+        "https://queue.amazonaws.com/123456789012/email.baz")
     sorted_children[1].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/email.foobar"
-    )
+        "https://queue.amazonaws.com/123456789012/email.foobar")
 
 
 @mock_sqs
@@ -70,13 +62,11 @@ def test_manager_start_and_stop():
     """
     Test managing process can start and stop child processes
     """
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="email")
 
     manager = ManagerWorker(
-        queue_prefixes=["email"],
-        worker_concurrency=2,
-        interval=1,
+        queue_prefixes=['email'], worker_concurrency=2, interval=1,
         batchsize=10,
     )
 
@@ -105,14 +95,8 @@ def test_main_method(ManagerWorker):
     _main(["email1", "email2"], concurrency=2)
 
     ManagerWorker.assert_called_once_with(
-        ["email1", "email2"],
-        2,
-        1,
-        10,
-        prefetch_multiplier=2,
-        region=None,
-        secret_access_key=None,
-        access_key_id=None,
+        ['email1', 'email2'], 2, 1, 10, prefetch_multiplier=2,
+        region=None, secret_access_key=None, access_key_id=None,
         endpoint_url=None,
     )
     ManagerWorker.return_value.start.assert_called_once_with()
@@ -126,31 +110,17 @@ def test_real_main_method(ArgumentParser, _main):
     Test parsing of arguments from main method
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3,
-        queues=["email1"],
-        interval=1,
-        batchsize=5,
-        logging_level="WARN",
-        region="us-east-1",
-        prefetch_multiplier=2,
-        access_key_id=None,
-        secret_access_key=None,
-        simple_worker=False,
+        concurrency=3, queues=["email1"], interval=1, batchsize=5,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=False,
         endpoint_url=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=["email1"],
-        concurrency=3,
-        interval=1,
-        batchsize=5,
-        logging_level="WARN",
-        region="us-east-1",
-        prefetch_multiplier=2,
-        access_key_id=None,
-        secret_access_key=None,
-        simple_worker=False,
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=5,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=False,
         endpoint_url=None,
     )
 
@@ -163,31 +133,17 @@ def test_real_main_method_default_batchsize(ArgumentParser, _main):
     Test parsing of arguments from main method batch default
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3,
-        queues=["email1"],
-        interval=1,
-        batchsize=None,
-        logging_level="WARN",
-        region="us-east-1",
-        prefetch_multiplier=2,
-        access_key_id=None,
-        secret_access_key=None,
-        simple_worker=False,
+        concurrency=3, queues=["email1"], interval=1, batchsize=None,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=False,
         endpoint_url=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=["email1"],
-        concurrency=3,
-        interval=1,
-        batchsize=10,
-        logging_level="WARN",
-        region="us-east-1",
-        prefetch_multiplier=2,
-        access_key_id=None,
-        secret_access_key=None,
-        simple_worker=False,
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=10,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=False,
         endpoint_url=None,
     )
 
@@ -199,7 +155,7 @@ def test_master_spawns_worker_processes():
     """
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
@@ -225,14 +181,12 @@ def test_master_replaces_reader_processes():
     """
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
         batchsize=10,
     )
     manager.start()
@@ -264,7 +218,7 @@ def test_master_counts_processes():
     logger.handlers.append(MockLoggingHandler())
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
@@ -279,9 +233,11 @@ def test_master_counts_processes():
 
     # Check messages
     msg1 = "Reader Processes: 1"
-    logger.handlers[0].messages["debug"][-2].lower().should.contain(msg1.lower())
+    logger.handlers[0].messages['debug'][-2].lower().should.contain(
+        msg1.lower())
     msg2 = "Worker Processes: 2"
-    logger.handlers[0].messages["debug"][-1].lower().should.contain(msg2.lower())
+    logger.handlers[0].messages['debug'][-1].lower().should.contain(
+        msg2.lower())
 
 
 @mock_sqs
@@ -290,14 +246,12 @@ def test_master_replaces_worker_processes():
     Test managing process replaces worker processes
     """
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
         batchsize=10,
     )
     manager.start()
@@ -325,7 +279,7 @@ def test_master_handles_signals(sys):
     """
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Mock out sys.exit
@@ -337,9 +291,7 @@ def test_master_handles_signals(sys):
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
         batchsize=10,
     )
     manager.process_counts = process_counts
@@ -361,26 +313,23 @@ def test_master_shuts_down_busy_read_workers():
     """
     # For debugging test
     import sys
-
     logger = logging.getLogger("pyqs")
     logger.setLevel(logging.DEBUG)
     stdout_handler = logging.StreamHandler(sys.stdout)
     logger.addHandler(stdout_handler)
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
-    queue_url = conn.create_queue(QueueName="tester")["QueueUrl"]
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
 
     # Add Slow tasks
-    message = json.dumps(
-        {
-            "task": "tests.tasks.sleeper",
-            "args": [],
-            "kwargs": {
-                "message": 5,
-            },
-        }
-    )
+    message = json.dumps({
+        'task': 'tests.tasks.sleeper',
+        'args': [],
+        'kwargs': {
+            'message': 5,
+        },
+    })
 
     # Fill the queue (we need a lot of messages to trigger the bug)
     for _ in range(20):
@@ -391,7 +340,6 @@ def test_master_shuts_down_busy_read_workers():
         import os
         import signal
         import time
-
         # This sleep time is long enoug for 100 messages in queue
         time.sleep(5)
         try:
@@ -405,9 +353,7 @@ def test_master_shuts_down_busy_read_workers():
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=0,
-        interval=0.0,
+        queue_prefixes=["tester"], worker_concurrency=0, interval=0.0,
         batchsize=1,
     )
     manager.start()
@@ -419,14 +365,12 @@ def test_master_shuts_down_busy_read_workers():
     try:
         # Try Python 2 Style
         thread = ThreadWithReturnValue2(
-            target=sleep_and_kill, args=(manager.reader_children[0].pid,)
-        )
+            target=sleep_and_kill, args=(manager.reader_children[0].pid,))
         thread.daemon = True
     except TypeError:
         # Use Python 3 Style
         thread = ThreadWithReturnValue3(
-            target=sleep_and_kill,
-            args=(manager.reader_children[0].pid,),
+            target=sleep_and_kill, args=(manager.reader_children[0].pid,),
             daemon=True,
         )
 
@@ -448,26 +392,23 @@ def test_master_shuts_down_busy_process_workers():
     """
     # For debugging test
     import sys
-
     logger = logging.getLogger("pyqs")
     logger.setLevel(logging.DEBUG)
     stdout_handler = logging.StreamHandler(sys.stdout)
     logger.addHandler(stdout_handler)
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
-    queue_url = conn.create_queue(QueueName="tester")["QueueUrl"]
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
 
     # Add Slow tasks
-    message = json.dumps(
-        {
-            "task": "tests.tasks.sleeper",
-            "args": [],
-            "kwargs": {
-                "message": 5,
-            },
-        }
-    )
+    message = json.dumps({
+        'task': 'tests.tasks.sleeper',
+        'args': [],
+        'kwargs': {
+            'message': 5,
+        },
+    })
 
     # Fill the queue (we need a lot of messages to trigger the bug)
     for _ in range(20):
@@ -478,7 +419,6 @@ def test_master_shuts_down_busy_process_workers():
         import os
         import signal
         import time
-
         # This sleep time is long enoug for 100 messages in queue
         time.sleep(5)
         try:
@@ -492,9 +432,7 @@ def test_master_shuts_down_busy_process_workers():
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=0.0,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=0.0,
         batchsize=1,
     )
     manager.start()
@@ -506,14 +444,12 @@ def test_master_shuts_down_busy_process_workers():
     try:
         # Try Python 2 Style
         thread = ThreadWithReturnValue2(
-            target=sleep_and_kill, args=(manager.reader_children[0].pid,)
-        )
+            target=sleep_and_kill, args=(manager.reader_children[0].pid,))
         thread.daemon = True
     except TypeError:
         # Use Python 3 Style
         thread = ThreadWithReturnValue3(
-            target=sleep_and_kill,
-            args=(manager.reader_children[0].pid,),
+            target=sleep_and_kill, args=(manager.reader_children[0].pid,),
             daemon=True,
         )
 
@@ -535,13 +471,11 @@ def test_manager_picks_up_new_queues():
     """
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
 
     # Setup Manager
     manager = ManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
         batchsize=10,
     )
     manager.start()
@@ -556,8 +490,7 @@ def test_manager_picks_up_new_queues():
     # The manager should have seen the new queue was created and add a reader
     len(manager.reader_children).should.equal(1)
     manager.reader_children[0].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/tester"
-    )
+        "https://queue.amazonaws.com/123456789012/tester")
 
     # Cleanup
     manager.stop()

--- a/tests/test_simple_manager_worker.py
+++ b/tests/test_simple_manager_worker.py
@@ -11,7 +11,9 @@ from moto import mock_sqs
 from pyqs.main import main, _main
 from pyqs.worker import SimpleManagerWorker
 from tests.utils import (
-    MockLoggingHandler, ThreadWithReturnValue2, ThreadWithReturnValue3,
+    MockLoggingHandler,
+    ThreadWithReturnValue2,
+    ThreadWithReturnValue3,
 )
 
 
@@ -20,11 +22,13 @@ def test_simple_manager_worker_create_proper_children_workers():
     """
     Test simple managing process creates multiple child workers
     """
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="email")
 
     manager = SimpleManagerWorker(
-        queue_prefixes=['email'], worker_concurrency=3, interval=2,
+        queue_prefixes=["email"],
+        worker_concurrency=3,
+        interval=2,
         batchsize=10,
     )
 
@@ -36,12 +40,14 @@ def test_simple_manager_worker_with_queue_prefix():
     """
     Test simple managing process can find queues by prefix
     """
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="email.foobar")
     conn.create_queue(QueueName="email.baz")
 
     manager = SimpleManagerWorker(
-        queue_prefixes=['email.*'], worker_concurrency=1, interval=1,
+        queue_prefixes=["email.*"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
 
@@ -51,9 +57,11 @@ def test_simple_manager_worker_with_queue_prefix():
     sorted_children = sorted(children, key=lambda child: child.queue_url)
 
     sorted_children[0].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/email.baz")
+        "https://queue.amazonaws.com/123456789012/email.baz"
+    )
     sorted_children[1].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/email.foobar")
+        "https://queue.amazonaws.com/123456789012/email.foobar"
+    )
 
 
 @mock_sqs
@@ -61,11 +69,13 @@ def test_simple_manager_start_and_stop():
     """
     Test simple managing process can start and stop child processes
     """
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="email")
 
     manager = SimpleManagerWorker(
-        queue_prefixes=['email'], worker_concurrency=2, interval=1,
+        queue_prefixes=["email"],
+        worker_concurrency=2,
+        interval=1,
         batchsize=10,
     )
 
@@ -94,8 +104,14 @@ def test_main_method(SimpleManagerWorker):
     _main(["email1", "email2"], concurrency=2, simple_worker=True)
 
     SimpleManagerWorker.assert_called_once_with(
-        ['email1', 'email2'], 2, 1, 10,
-        region=None, secret_access_key=None, access_key_id=None,
+        ["email1", "email2"],
+        2,
+        1,
+        10,
+        region=None,
+        secret_access_key=None,
+        access_key_id=None,
+        endpoint_url=None,
     )
     SimpleManagerWorker.return_value.start.assert_called_once_with()
 
@@ -108,16 +124,32 @@ def test_real_main_method(ArgumentParser, _main):
     Test parsing of arguments from main method
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3, queues=["email1"], interval=1, batchsize=5,
-        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None, simple_worker=True,
+        concurrency=3,
+        queues=["email1"],
+        interval=1,
+        batchsize=5,
+        logging_level="WARN",
+        region="us-east-1",
+        prefetch_multiplier=2,
+        access_key_id=None,
+        secret_access_key=None,
+        simple_worker=True,
+        endpoint_url=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=5,
-        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None, simple_worker=True,
+        queue_prefixes=["email1"],
+        concurrency=3,
+        interval=1,
+        batchsize=5,
+        logging_level="WARN",
+        region="us-east-1",
+        prefetch_multiplier=2,
+        access_key_id=None,
+        secret_access_key=None,
+        simple_worker=True,
+        endpoint_url=None,
     )
 
 
@@ -129,16 +161,32 @@ def test_real_main_method_default_batchsize(ArgumentParser, _main):
     Test parsing of arguments from main method batch default
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3, queues=["email1"], interval=1, batchsize=None,
-        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None, simple_worker=True,
+        concurrency=3,
+        queues=["email1"],
+        interval=1,
+        batchsize=None,
+        logging_level="WARN",
+        region="us-east-1",
+        prefetch_multiplier=2,
+        access_key_id=None,
+        secret_access_key=None,
+        simple_worker=True,
+        endpoint_url=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=1,
-        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
-        access_key_id=None, secret_access_key=None, simple_worker=True,
+        queue_prefixes=["email1"],
+        concurrency=3,
+        interval=1,
+        batchsize=1,
+        logging_level="WARN",
+        region="us-east-1",
+        prefetch_multiplier=2,
+        access_key_id=None,
+        secret_access_key=None,
+        simple_worker=True,
+        endpoint_url=None,
     )
 
 
@@ -149,7 +197,7 @@ def test_master_spawns_worker_processes():
     """
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
@@ -177,7 +225,7 @@ def test_master_counts_processes():
     logger.handlers.append(MockLoggingHandler())
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
@@ -192,8 +240,7 @@ def test_master_counts_processes():
 
     # Check messages
     msg2 = "Worker Processes: 2"
-    logger.handlers[0].messages['debug'][-1].lower().should.contain(
-        msg2.lower())
+    logger.handlers[0].messages["debug"][-1].lower().should.contain(msg2.lower())
 
 
 @mock_sqs
@@ -202,12 +249,14 @@ def test_master_replaces_worker_processes():
     Test simple managing process replaces worker processes
     """
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
     manager = SimpleManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
     manager.start()
@@ -235,7 +284,7 @@ def test_master_handles_signals(sys):
     """
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
     conn.create_queue(QueueName="tester")
 
     # Mock out sys.exit
@@ -247,7 +296,9 @@ def test_master_handles_signals(sys):
 
     # Setup Manager
     manager = SimpleManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
     manager.process_counts = process_counts
@@ -268,23 +319,26 @@ def test_master_shuts_down_busy_process_workers():
     """
     # For debugging test
     import sys
+
     logger = logging.getLogger("pyqs")
     logger.setLevel(logging.DEBUG)
     stdout_handler = logging.StreamHandler(sys.stdout)
     logger.addHandler(stdout_handler)
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
-    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
+    conn = boto3.client("sqs", region_name="us-east-1")
+    queue_url = conn.create_queue(QueueName="tester")["QueueUrl"]
 
     # Add Slow tasks
-    message = json.dumps({
-        'task': 'tests.tasks.sleeper',
-        'args': [],
-        'kwargs': {
-            'message': 5,
-        },
-    })
+    message = json.dumps(
+        {
+            "task": "tests.tasks.sleeper",
+            "args": [],
+            "kwargs": {
+                "message": 5,
+            },
+        }
+    )
 
     # Fill the queue (we need a lot of messages to trigger the bug)
     for _ in range(20):
@@ -295,6 +349,7 @@ def test_master_shuts_down_busy_process_workers():
         import os
         import signal
         import time
+
         # This sleep time is long enoug for 100 messages in queue
         time.sleep(5)
         try:
@@ -308,7 +363,9 @@ def test_master_shuts_down_busy_process_workers():
 
     # Setup Manager
     manager = SimpleManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=0.0,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=0.0,
         batchsize=1,
     )
     manager.start()
@@ -320,12 +377,14 @@ def test_master_shuts_down_busy_process_workers():
     try:
         # Try Python 2 Style
         thread = ThreadWithReturnValue2(
-            target=sleep_and_kill, args=(manager.worker_children[0].pid,))
+            target=sleep_and_kill, args=(manager.worker_children[0].pid,)
+        )
         thread.daemon = True
     except TypeError:
         # Use Python 3 Style
         thread = ThreadWithReturnValue3(
-            target=sleep_and_kill, args=(manager.worker_children[0].pid,),
+            target=sleep_and_kill,
+            args=(manager.worker_children[0].pid,),
             daemon=True,
         )
 
@@ -347,11 +406,13 @@ def test_manager_picks_up_new_queues():
     """
 
     # Setup SQS Queue
-    conn = boto3.client('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name="us-east-1")
 
     # Setup Manager
     manager = SimpleManagerWorker(
-        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
+        queue_prefixes=["tester"],
+        worker_concurrency=1,
+        interval=1,
         batchsize=10,
     )
     manager.start()
@@ -366,7 +427,8 @@ def test_manager_picks_up_new_queues():
     # The manager should have seen the new queue was created and add a reader
     len(manager.worker_children).should.equal(1)
     manager.worker_children[0].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/tester")
+        "https://queue.amazonaws.com/123456789012/tester"
+    )
 
     # Cleanup
     manager.stop()

--- a/tests/test_simple_manager_worker.py
+++ b/tests/test_simple_manager_worker.py
@@ -11,9 +11,7 @@ from moto import mock_sqs
 from pyqs.main import main, _main
 from pyqs.worker import SimpleManagerWorker
 from tests.utils import (
-    MockLoggingHandler,
-    ThreadWithReturnValue2,
-    ThreadWithReturnValue3,
+    MockLoggingHandler, ThreadWithReturnValue2, ThreadWithReturnValue3,
 )
 
 
@@ -22,13 +20,11 @@ def test_simple_manager_worker_create_proper_children_workers():
     """
     Test simple managing process creates multiple child workers
     """
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="email")
 
     manager = SimpleManagerWorker(
-        queue_prefixes=["email"],
-        worker_concurrency=3,
-        interval=2,
+        queue_prefixes=['email'], worker_concurrency=3, interval=2,
         batchsize=10,
     )
 
@@ -40,14 +36,12 @@ def test_simple_manager_worker_with_queue_prefix():
     """
     Test simple managing process can find queues by prefix
     """
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="email.foobar")
     conn.create_queue(QueueName="email.baz")
 
     manager = SimpleManagerWorker(
-        queue_prefixes=["email.*"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=['email.*'], worker_concurrency=1, interval=1,
         batchsize=10,
     )
 
@@ -57,11 +51,9 @@ def test_simple_manager_worker_with_queue_prefix():
     sorted_children = sorted(children, key=lambda child: child.queue_url)
 
     sorted_children[0].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/email.baz"
-    )
+        "https://queue.amazonaws.com/123456789012/email.baz")
     sorted_children[1].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/email.foobar"
-    )
+        "https://queue.amazonaws.com/123456789012/email.foobar")
 
 
 @mock_sqs
@@ -69,13 +61,11 @@ def test_simple_manager_start_and_stop():
     """
     Test simple managing process can start and stop child processes
     """
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="email")
 
     manager = SimpleManagerWorker(
-        queue_prefixes=["email"],
-        worker_concurrency=2,
-        interval=1,
+        queue_prefixes=['email'], worker_concurrency=2, interval=1,
         batchsize=10,
     )
 
@@ -104,13 +94,8 @@ def test_main_method(SimpleManagerWorker):
     _main(["email1", "email2"], concurrency=2, simple_worker=True)
 
     SimpleManagerWorker.assert_called_once_with(
-        ["email1", "email2"],
-        2,
-        1,
-        10,
-        region=None,
-        secret_access_key=None,
-        access_key_id=None,
+        ['email1', 'email2'], 2, 1, 10,
+        region=None, secret_access_key=None, access_key_id=None,
         endpoint_url=None,
     )
     SimpleManagerWorker.return_value.start.assert_called_once_with()
@@ -124,31 +109,17 @@ def test_real_main_method(ArgumentParser, _main):
     Test parsing of arguments from main method
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3,
-        queues=["email1"],
-        interval=1,
-        batchsize=5,
-        logging_level="WARN",
-        region="us-east-1",
-        prefetch_multiplier=2,
-        access_key_id=None,
-        secret_access_key=None,
-        simple_worker=True,
+        concurrency=3, queues=["email1"], interval=1, batchsize=5,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=True,
         endpoint_url=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=["email1"],
-        concurrency=3,
-        interval=1,
-        batchsize=5,
-        logging_level="WARN",
-        region="us-east-1",
-        prefetch_multiplier=2,
-        access_key_id=None,
-        secret_access_key=None,
-        simple_worker=True,
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=5,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=True,
         endpoint_url=None,
     )
 
@@ -161,31 +132,17 @@ def test_real_main_method_default_batchsize(ArgumentParser, _main):
     Test parsing of arguments from main method batch default
     """
     ArgumentParser.return_value.parse_args.return_value = Mock(
-        concurrency=3,
-        queues=["email1"],
-        interval=1,
-        batchsize=None,
-        logging_level="WARN",
-        region="us-east-1",
-        prefetch_multiplier=2,
-        access_key_id=None,
-        secret_access_key=None,
-        simple_worker=True,
+        concurrency=3, queues=["email1"], interval=1, batchsize=None,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=True,
         endpoint_url=None,
     )
     main()
 
     _main.assert_called_once_with(
-        queue_prefixes=["email1"],
-        concurrency=3,
-        interval=1,
-        batchsize=1,
-        logging_level="WARN",
-        region="us-east-1",
-        prefetch_multiplier=2,
-        access_key_id=None,
-        secret_access_key=None,
-        simple_worker=True,
+        queue_prefixes=['email1'], concurrency=3, interval=1, batchsize=1,
+        logging_level="WARN", region='us-east-1', prefetch_multiplier=2,
+        access_key_id=None, secret_access_key=None, simple_worker=True,
         endpoint_url=None,
     )
 
@@ -197,7 +154,7 @@ def test_master_spawns_worker_processes():
     """
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
@@ -225,7 +182,7 @@ def test_master_counts_processes():
     logger.handlers.append(MockLoggingHandler())
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
@@ -240,7 +197,8 @@ def test_master_counts_processes():
 
     # Check messages
     msg2 = "Worker Processes: 2"
-    logger.handlers[0].messages["debug"][-1].lower().should.contain(msg2.lower())
+    logger.handlers[0].messages['debug'][-1].lower().should.contain(
+        msg2.lower())
 
 
 @mock_sqs
@@ -249,14 +207,12 @@ def test_master_replaces_worker_processes():
     Test simple managing process replaces worker processes
     """
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Setup Manager
     manager = SimpleManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
         batchsize=10,
     )
     manager.start()
@@ -284,7 +240,7 @@ def test_master_handles_signals(sys):
     """
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
     conn.create_queue(QueueName="tester")
 
     # Mock out sys.exit
@@ -296,9 +252,7 @@ def test_master_handles_signals(sys):
 
     # Setup Manager
     manager = SimpleManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
         batchsize=10,
     )
     manager.process_counts = process_counts
@@ -319,26 +273,23 @@ def test_master_shuts_down_busy_process_workers():
     """
     # For debugging test
     import sys
-
     logger = logging.getLogger("pyqs")
     logger.setLevel(logging.DEBUG)
     stdout_handler = logging.StreamHandler(sys.stdout)
     logger.addHandler(stdout_handler)
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
-    queue_url = conn.create_queue(QueueName="tester")["QueueUrl"]
+    conn = boto3.client('sqs', region_name='us-east-1')
+    queue_url = conn.create_queue(QueueName="tester")['QueueUrl']
 
     # Add Slow tasks
-    message = json.dumps(
-        {
-            "task": "tests.tasks.sleeper",
-            "args": [],
-            "kwargs": {
-                "message": 5,
-            },
-        }
-    )
+    message = json.dumps({
+        'task': 'tests.tasks.sleeper',
+        'args': [],
+        'kwargs': {
+            'message': 5,
+        },
+    })
 
     # Fill the queue (we need a lot of messages to trigger the bug)
     for _ in range(20):
@@ -349,7 +300,6 @@ def test_master_shuts_down_busy_process_workers():
         import os
         import signal
         import time
-
         # This sleep time is long enoug for 100 messages in queue
         time.sleep(5)
         try:
@@ -363,9 +313,7 @@ def test_master_shuts_down_busy_process_workers():
 
     # Setup Manager
     manager = SimpleManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=0.0,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=0.0,
         batchsize=1,
     )
     manager.start()
@@ -377,14 +325,12 @@ def test_master_shuts_down_busy_process_workers():
     try:
         # Try Python 2 Style
         thread = ThreadWithReturnValue2(
-            target=sleep_and_kill, args=(manager.worker_children[0].pid,)
-        )
+            target=sleep_and_kill, args=(manager.worker_children[0].pid,))
         thread.daemon = True
     except TypeError:
         # Use Python 3 Style
         thread = ThreadWithReturnValue3(
-            target=sleep_and_kill,
-            args=(manager.worker_children[0].pid,),
+            target=sleep_and_kill, args=(manager.worker_children[0].pid,),
             daemon=True,
         )
 
@@ -406,13 +352,11 @@ def test_manager_picks_up_new_queues():
     """
 
     # Setup SQS Queue
-    conn = boto3.client("sqs", region_name="us-east-1")
+    conn = boto3.client('sqs', region_name='us-east-1')
 
     # Setup Manager
     manager = SimpleManagerWorker(
-        queue_prefixes=["tester"],
-        worker_concurrency=1,
-        interval=1,
+        queue_prefixes=["tester"], worker_concurrency=1, interval=1,
         batchsize=10,
     )
     manager.start()
@@ -427,8 +371,7 @@ def test_manager_picks_up_new_queues():
     # The manager should have seen the new queue was created and add a reader
     len(manager.worker_children).should.equal(1)
     manager.worker_children[0].queue_url.should.equal(
-        "https://queue.amazonaws.com/123456789012/tester"
-    )
+        "https://queue.amazonaws.com/123456789012/tester")
 
     # Cleanup
     manager.stop()


### PR DESCRIPTION
## About
- Update tests so they account for the new `--endpoint-url` flag